### PR TITLE
Issue #18: Make sure the application is disposed when it is removed

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplicationFactory.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplicationFactory.java
@@ -79,12 +79,7 @@ public class CodewindApplicationFactory {
 			if (projectID == null) {
 				for (String id : connection.getAppIds()) {
 					if (!idSet.contains(id)) {
-						CodewindApplication app = connection.getAppByID(id);
 						connection.removeApp(id);
-						if (app != null) {
-							CoreUtil.removeApplication(app);
-							app.dispose();
-						}
 					}
 				}
 			}

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
@@ -309,16 +309,23 @@ public class CodewindConnection {
 		}
 	}
 
-	public CodewindApplication removeApp(String projectID) {
+	public void removeApp(String projectID) {
+		CodewindApplication app = null;
 		synchronized(appMap) {
-			return appMap.remove(projectID);
+			app = appMap.remove(projectID);
+		}
+		if (app != null) {
+			CoreUtil.removeApplication(app);
+			app.dispose();
+		} else {
+			Logger.logError("No application found for project being deleted: " + projectID); //$NON-NLS-1$
 		}
 	}
 
 	/**
 	 * @return The app with the given ID, if it exists in this Codewind instance, else null.
 	 */
-	public synchronized CodewindApplication getAppByID(String projectID) {
+	public CodewindApplication getAppByID(String projectID) {
 		synchronized(appMap) {
 			return appMap.get(projectID);
 		}

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindSocket.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindSocket.java
@@ -403,13 +403,7 @@ public class CodewindSocket {
 
 	private void onProjectDeletion(JSONObject event) throws JSONException {
 		String projectID = event.getString(CoreConstants.KEY_PROJECT_ID);
-		CodewindApplication app = connection.removeApp(projectID);
-		if (app == null) {
-			Logger.logError("No application found for project being deleted: " + projectID); //$NON-NLS-1$
-			return;
-		}
-		CoreUtil.removeApplication(app);
-		app.dispose();
+		connection.removeApp(projectID);
 	}
 
 	public void registerSocketConsole(SocketConsole console) {


### PR DESCRIPTION
There was a spot in the code where dispose was not being called on an application that was removed which was causing log consoles to be left around.  Move the dispose call into the removeApp method so that it always gets called when an app is removed.