### PR TITLE
Issue #34: For project create, get the project type from the template info

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/console/ProjectTemplateInfo.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/console/ProjectTemplateInfo.java
@@ -21,6 +21,7 @@ public class ProjectTemplateInfo {
 	public static final String DESCRIPTION_KEY = "description";
 	public static final String URL_KEY = "url";
 	public static final String LANGUAGE_KEY = "language";
+	public static final String PROJECT_TYPE_KEY = "projectType";
 	
 	private JSONObject projectInfo;
 	
@@ -42,6 +43,10 @@ public class ProjectTemplateInfo {
 	
 	public String getUrl() {
 		return getString(URL_KEY);
+	}
+	
+	public String getProjectType() {
+		return getString(PROJECT_TYPE_KEY);
 	}
 	
 	private String getString(String key) {

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectWizard.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectWizard.java
@@ -91,29 +91,7 @@ public class NewCodewindProjectWizard extends Wizard implements INewWizard {
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
 					newConnection.requestProjectCreate(info, name);
-					ProjectLanguage language = ProjectLanguage.getLanguage(info.getLanguage());
-					String type = null;
-					switch(language) {
-						case LANGUAGE_JAVA:
-							if (info.getLabel().toLowerCase().contains("spring")) {
-								type = "spring";
-							} else if (info.getLabel().toLowerCase().contains("microprofile")) {
-								type = "liberty";
-							} else {
-								type = "docker";
-							}
-							break;
-						case LANGUAGE_NODEJS:
-							type = "nodejs";
-							break;
-						case LANGUAGE_SWIFT:
-							type = "swift";
-							break;
-						default:
-							type = "docker";
-							break;
-					}
-					newConnection.requestProjectBind(name, newConnection.getWorkspacePath() + "/" + name, info.getLanguage(), type);
+					newConnection.requestProjectBind(name, newConnection.getWorkspacePath() + "/" + name, info.getLanguage(), info.getProjectType());
 					if (CodewindConnectionManager.getActiveConnection(newConnection.baseUrl.toString()) == null) {
 						CodewindConnectionManager.add(newConnection);
 					}


### PR DESCRIPTION
For project create, the project type is now in the template info.  Pass this in on the bind step instead of calculating it.