### PR TITLE
Issue #32: Select project if only one in project selection page

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectSelectionPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectSelectionPage.java
@@ -134,6 +134,12 @@ public class ProjectSelectionPage extends WizardPage {
 			}
         });
         
+        if (projectList.getTable().getItemCount() == 1) {
+        	Object element = projectList.getElementAt(0);
+        	projectList.setChecked(element, true);
+        	project = (IProject) element;
+        }
+
         filterText.setFocus();
         setControl(composite);
 	}


### PR DESCRIPTION
If there is only one project in the add existing project selection page then select it automatically.