### PR TITLE
Issue #45: Add a stop application containers preference

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/CodewindCorePlugin.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/CodewindCorePlugin.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import org.eclipse.codewind.core.internal.CodewindEclipseApplication;
 import org.eclipse.codewind.core.internal.IDebugLauncher;
 import org.eclipse.codewind.core.internal.IUpdateHandler;
+import org.eclipse.codewind.core.internal.InstallUtil;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.constants.ProjectLanguage;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -67,6 +68,8 @@ public class CodewindCorePlugin extends AbstractUIPlugin {
 		context.registerService(DebugOptionsListener.class, Logger.instance(), null);
 
 		// Set default preferences once, here
+		getPreferenceStore().setDefault(InstallUtil.STOP_APP_CONTAINERS_PREFSKEY,
+				InstallUtil.STOP_APP_CONTAINERS_DEFAULT);
 		getPreferenceStore().setDefault(DEBUG_CONNECT_TIMEOUT_PREFSKEY,
 				CodewindEclipseApplication.DEFAULT_DEBUG_CONNECT_TIMEOUT);
 	}

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/InstallUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/InstallUtil.java
@@ -35,6 +35,12 @@ import org.eclipse.core.runtime.SubMonitor;
 
 public class InstallUtil {
 	
+	public static final String STOP_APP_CONTAINERS_PREFSKEY = "stopAppContainers";
+	public static final String STOP_APP_CONTAINERS_ALWAYS = "stopAppContainersAlways";
+	public static final String STOP_APP_CONTAINERS_NEVER = "stopAppContainersNever";
+	public static final String STOP_APP_CONTAINERS_PROMPT = "stopAppContainersPrompt";
+	public static final String STOP_APP_CONTAINERS_DEFAULT = STOP_APP_CONTAINERS_PROMPT;
+	
 	private static final Map<OperatingSystem, String> installMap = new HashMap<OperatingSystem, String>();
 
 	static {
@@ -47,6 +53,7 @@ public class InstallUtil {
 	private static final String INSTALL_DEV_CMD = "install-dev";
 	private static final String INSTALL_CMD = "install";
 	private static final String START_CMD = "start";
+	private static final String STOP_CMD = "stop";
 	private static final String STOP_ALL_CMD = "stop-all";
 	private static final String STATUS_CMD = "status";
 	private static final String REMOVE_CMD = "remove";
@@ -102,11 +109,11 @@ public class InstallUtil {
 		}
 	}
 	
-	public static ProcessResult stopCodewind(IProgressMonitor monitor) throws IOException, TimeoutException {
+	public static ProcessResult stopCodewind(boolean stopAll, IProgressMonitor monitor) throws IOException, TimeoutException {
 		SubMonitor mon = SubMonitor.convert(monitor, Messages.StopCodewindJobLabel, 100);
 		Process process = null;
 		try {
-		    process = runInstaller(STOP_ALL_CMD);
+		    process = runInstaller(stopAll ? STOP_ALL_CMD : STOP_CMD);
 		    ProcessResult result = ProcessHelper.waitForProcess(process, 500, 60, mon);
 		    return result;
 		} finally {

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/ProcessHelper.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/ProcessHelper.java
@@ -75,7 +75,12 @@ public class ProcessHelper {
                 } catch (InterruptedException e) {
                     // ignore
                 }
-                
+
+                if (mon.isCanceled()) {
+                	p.destroy();
+                	return new ProcessResult(0, "", "");
+                }
+
                 mon.worked(1);
                 mon.setWorkRemaining(work);
 

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -23,6 +23,10 @@ public class Messages extends NLS {
 	public static String ConnectionPrefsPage_TableTitleLabel;
 	public static String ConnectionPrefsPage_URLColumn;
 
+	public static String PrefsParentPage_StopAppsLabel;
+	public static String PrefsParentPage_StopAppsAlways;
+	public static String PrefsParentPage_StopAppsNever;
+	public static String PrefsParentPage_StopAppsPrompt;
 	public static String PrefsParentPage_DebugTimeoutLabel;
 	public static String PrefsParentPage_ErrInvalidDebugTimeout;
 
@@ -238,6 +242,10 @@ public class Messages extends NLS {
 	public static String AppOverviewEditorOpenSettingsErrorTitle;
 	public static String AppOverviewEditorOpenSettingsErrorMsg;
 	public static String AppOverviewEditorOpenSettingsNotFound;
+	
+	public static String StopAllDialog_Title;
+	public static String StopAllDialog_Message;
+	public static String StopAllDialog_ToggleMessage;
 	
 	static {
 		// initialize resource bundle

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -16,6 +16,10 @@ ConnectionPrefsPage_ShellTitle=Codewind connections
 ConnectionPrefsPage_TableTitleLabel=Create or remove connections
 ConnectionPrefsPage_URLColumn=URL
 
+PrefsParentPage_StopAppsLabel=&Stop application containers when stopping Codewind:
+PrefsParentPage_StopAppsAlways=&Always
+PrefsParentPage_StopAppsNever=&Never
+PrefsParentPage_StopAppsPrompt=&Prompt
 PrefsParentPage_DebugTimeoutLabel=&Timeout for the server debug connection in seconds:
 PrefsParentPage_ErrInvalidDebugTimeout=The value "{0}" for the debug timeout is not valid. Enter an integer greater than 0.
 
@@ -231,3 +235,7 @@ AppOverviewEditorNotAvailable=Not available
 AppOverviewEditorOpenSettingsErrorTitle=Error Opening Project Settings
 AppOverviewEditorOpenSettingsErrorMsg=An error occurred while opening the project settings:\n\n{0}
 AppOverviewEditorOpenSettingsNotFound=The project settings file ''.cw-settings'' could not be found or was not accessible.
+
+StopAllDialog_Title=Stopping Codewind
+StopAllDialog_Message=Do you want to stop your application containers as well?
+StopAllDialog_ToggleMessage=Remember my choice and don't show this dialog again

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/CodewindPrefsParentPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/CodewindPrefsParentPage.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.codewind.core.CodewindCorePlugin;
+import org.eclipse.codewind.core.internal.InstallUtil;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.messages.Messages;
@@ -28,6 +29,7 @@ import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
@@ -51,6 +53,7 @@ public class CodewindPrefsParentPage extends PreferencePage implements IWorkbenc
 	private Text debugTimeoutText;
 	private Combo webBrowserCombo;
 	private Text selectWebBrowserLabel;
+	private Button[] stopAppsButtons = new Button[3];
 		
 	private String browserName = null;
 
@@ -74,6 +77,37 @@ public class CodewindPrefsParentPage extends PreferencePage implements IWorkbenc
 	    composite.setLayout(layout);
 	    composite.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_FILL | GridData.VERTICAL_ALIGN_FILL));
 
+	    Label stopAppContainersLabel = new Label(composite, SWT.NONE);
+	    stopAppContainersLabel.setText(Messages.PrefsParentPage_StopAppsLabel);
+	    stopAppContainersLabel.setLayoutData(new GridData(GridData.BEGINNING, GridData.FILL, false, false, 2, 1));
+
+	    Composite stopAppsComposite = new Composite(composite, SWT.NONE);
+	    layout = new GridLayout();
+	    layout.horizontalSpacing = convertHorizontalDLUsToPixels(4);
+	    layout.verticalSpacing = convertVerticalDLUsToPixels(3);
+	    layout.marginWidth = 20;
+	    layout.marginHeight = 2;
+	    layout.numColumns = 3;
+	    stopAppsComposite.setLayout(layout);
+	    stopAppsComposite.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false, 2, 1));
+
+	    stopAppsButtons[0] = new Button(stopAppsComposite, SWT.RADIO);
+	    stopAppsButtons[0].setText(Messages.PrefsParentPage_StopAppsAlways);
+	    stopAppsButtons[0].setData(InstallUtil.STOP_APP_CONTAINERS_ALWAYS);
+
+	    stopAppsButtons[1] = new Button(stopAppsComposite, SWT.RADIO);
+	    stopAppsButtons[1].setText(Messages.PrefsParentPage_StopAppsNever);
+	    stopAppsButtons[1].setData(InstallUtil.STOP_APP_CONTAINERS_NEVER);
+
+	    stopAppsButtons[2] = new Button(stopAppsComposite, SWT.RADIO);
+	    stopAppsButtons[2].setText(Messages.PrefsParentPage_StopAppsPrompt);
+	    stopAppsButtons[2].setData(InstallUtil.STOP_APP_CONTAINERS_PROMPT);
+
+	    setStopAppsSelection(prefs.getString(InstallUtil.STOP_APP_CONTAINERS_PREFSKEY));
+
+	    Label separator = new Label(composite, SWT.HORIZONTAL);
+	    separator.setLayoutData(new GridData(GridData.FILL_HORIZONTAL, GridData.CENTER, true, false, 2, 1));
+
 		Label debugTimeoutLabel = new Label(composite, SWT.READ_ONLY);
 		debugTimeoutLabel.setText(Messages.PrefsParentPage_DebugTimeoutLabel);
 		debugTimeoutLabel.setLayoutData(new GridData(GridData.BEGINNING, GridData.FILL, false, false));
@@ -94,7 +128,7 @@ public class CodewindPrefsParentPage extends PreferencePage implements IWorkbenc
 			}
 		});
 		
-		Label separator = new Label(composite, SWT.HORIZONTAL);
+		separator = new Label(composite, SWT.HORIZONTAL);
 	    separator.setLayoutData(new GridData(GridData.FILL_HORIZONTAL, GridData.CENTER, true, false, 2, 1));
 	    	    	    
 	    Text browserSelectionLabel = new Text(composite, SWT.READ_ONLY | SWT.SINGLE);
@@ -141,6 +175,15 @@ public class CodewindPrefsParentPage extends PreferencePage implements IWorkbenc
 
 		return composite;
 	}
+	
+	private void setStopAppsSelection(String selection) {
+		for (Button button : stopAppsButtons) {
+			if (button.getData().equals(selection)) {
+				button.setSelection(true);
+				break;
+			}
+		}
+	}
 
 	private void validate() {
 		String invalidReason = null;
@@ -166,7 +209,14 @@ public class CodewindPrefsParentPage extends PreferencePage implements IWorkbenc
 		if (!isValid()) {
 			return false;
 		}
-
+		
+		for (Button button : stopAppsButtons) {
+			if (button.getSelection()) {
+				prefs.setValue(InstallUtil.STOP_APP_CONTAINERS_PREFSKEY, (String)button.getData());
+				break;
+			}
+		}
+		
 		// validate in validate() that this is a good integer
 		int debugTimeout = Integer.parseInt(debugTimeoutText.getText().trim());
 		prefs.setValue(CodewindCorePlugin.DEBUG_CONNECT_TIMEOUT_PREFSKEY, debugTimeout);
@@ -193,6 +243,7 @@ public class CodewindPrefsParentPage extends PreferencePage implements IWorkbenc
 	
 	@Override
 	public void performDefaults() {
+		setStopAppsSelection(prefs.getDefaultString(InstallUtil.STOP_APP_CONTAINERS_PREFSKEY));
 		debugTimeoutText.setText("" + 	//$NON-NLS-1$
 				prefs.getDefaultInt(CodewindCorePlugin.DEBUG_CONNECT_TIMEOUT_PREFSKEY));
 		webBrowserCombo.select(0);


### PR DESCRIPTION
Fixes #45

Allow the user to decide whether stopping Codewind also stops application containers:

- Added a preference with always, never and prompt choices - prompt is the default
- If preference is set to prompt a dialog shows asking the user if they want to delete application containers
- The dialog also has a checkbox to save the user's choice and don't show the dialog again (this will set the preference)
- Also fixed a problem with ProcessHelper where waitForProcess was not checking if the monitor was canceled
- Added monitor canceled checks in CodewindInstall after each step