### PR TITLE
Issue #53: Don't prompt on stop if there are no active apps

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindManager.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindManager.java
@@ -101,5 +101,22 @@ public class CodewindManager {
 			localConnection = null;
 		}
 	}
+	
+	public void refresh() {
+		for (CodewindConnection conn : CodewindConnectionManager.activeConnections()) {
+			conn.refreshApps(null);
+		}
+	}
+	
+	public boolean hasActiveApplications() {
+		for (CodewindConnection conn : CodewindConnectionManager.activeConnections()) {
+			for (CodewindApplication app : conn.getApps()) {
+				if (app.isAvailable()) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
 
 }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/CodewindInstall.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/CodewindInstall.java
@@ -16,6 +16,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.TimeoutException;
 
 import org.eclipse.codewind.core.CodewindCorePlugin;
+import org.eclipse.codewind.core.internal.CodewindManager;
 import org.eclipse.codewind.core.internal.InstallUtil;
 import org.eclipse.codewind.core.internal.InstallUtil.InstallerStatus;
 import org.eclipse.codewind.core.internal.Logger;
@@ -296,6 +297,9 @@ public class CodewindInstall {
 	private static boolean getStopAll(IProgressMonitor monitor) {
 		IPreferenceStore prefs = CodewindCorePlugin.getDefault().getPreferenceStore();
 		if (InstallUtil.STOP_APP_CONTAINERS_PROMPT.contentEquals(prefs.getString(InstallUtil.STOP_APP_CONTAINERS_PREFSKEY))) {
+			if (!CodewindManager.getManager().hasActiveApplications()) {
+				return false;
+			}
 			final boolean[] stopApps = new boolean[] {false};
 			Display.getDefault().syncExec(new Runnable() {
 

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RefreshAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RefreshAction.java
@@ -61,6 +61,7 @@ public class RefreshAction implements IObjectActionDelegate {
     		Job job = new Job(Messages.RefreshCodewindJobLabel) {
     			@Override
     			protected IStatus run(IProgressMonitor monitor) {
+    				((CodewindManager)codewindObject).refresh();
 		        	ViewHelper.refreshCodewindExplorerView(codewindObject);
 		        	return Status.OK_STATUS;
     			}


### PR DESCRIPTION
 Fixes #53 

If there are no active applications then don't prompt the user to stop applications when stopping Codewind.  Also fixed a problem with refreshing the root Codewind element in the explorer view.