### PR TITLE
Issue #63: Remove borders on text fields in app overview (Linux)

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
@@ -484,6 +484,7 @@ public class ApplicationOverviewEditorPart extends EditorPart {
 	        setBold(label);
 	        
 	        text = new Text(composite, SWT.WRAP | SWT.MULTI | SWT.READ_ONLY);
+	        text.setData(FormToolkit.KEY_DRAW_BORDER, Boolean.FALSE);
 	        text.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false));
 		}
 		
@@ -561,7 +562,8 @@ public class ApplicationOverviewEditorPart extends EditorPart {
 			setBold(label);
 	        
 			// If not available then use a text field
-			text = new Text(composite, SWT.READ_ONLY);
+			text = new Text(composite, SWT.WRAP | SWT.MULTI | SWT.READ_ONLY);
+			text.setData(FormToolkit.KEY_DRAW_BORDER, Boolean.FALSE);
 			text.setText(Messages.AppOverviewEditorNotAvailable);
 			text.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, false, false));
 	        


### PR DESCRIPTION
Fixes #63

Removed the borders that were showing on the text fields in the application overview on Linux.  Also changed the Application URL text field to have the same style as other text fields since it was affecting the spacing on Linux.