### PR TITLE
Issue 67: Fix overview page application URL on Linux

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
@@ -232,6 +232,7 @@ public class ApplicationOverviewEditorPart extends EditorPart {
 		generalSection.update(app);
 		projectSettingsSection.update(app);
 		buildSection.update(app);
+		form.layout(true, true);
 		form.reflow(true);
 	}
 	


### PR DESCRIPTION
Fixes #67

The application URL when it switches from being a hyperlink to just text was getting lost altogether on Linux.  Adding a call to layout on the form fixes the problem.