### PR TITLE
Issue #19: Use unique ids for the app and perf monitor pages.

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
@@ -921,7 +921,7 @@ public class CodewindConnection {
 	public URL getPerformanceMonitorURL(CodewindApplication app) {
 		try {
 			URI uri = baseUrl;
-			uri = uri.resolve("performance/charts");
+			uri = uri.resolve(CoreConstants.PERF_MONITOR);
 			String query = CoreConstants.QUERY_PROJECT + "=" + app.projectID;
 			uri = new URI(uri.getScheme(), uri.getAuthority(), uri.getPath(), query, uri.getFragment());
 			return uri.toURL();

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/CoreConstants.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/CoreConstants.java
@@ -139,7 +139,8 @@ public class CoreConstants {
 			QUERY_PROJECT = "project",
 			QUERY_VIEW = "view",
 			VIEW_MONITOR = "monitor",
-			VIEW_OVERVIEW = "overview"
+			VIEW_OVERVIEW = "overview",
+			PERF_MONITOR = "performance/charts"
 
 			;
 

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/OpenPerfMonitorAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/OpenPerfMonitorAction.java
@@ -89,7 +89,7 @@ public class OpenPerfMonitorAction extends SelectionProviderAction {
 				// the browser will be re-used
 				browser = browserSupport
 						.createBrowser(IWorkbenchBrowserSupport.NAVIGATION_BAR | IWorkbenchBrowserSupport.LOCATION_BAR,
-								app.projectID + "_" + CoreConstants.VIEW_MONITOR, app.name, NLS.bind(Messages.BrowserTooltipPerformanceMonitor, app.name));
+								app.projectID + "_" + CoreConstants.PERF_MONITOR, app.name, NLS.bind(Messages.BrowserTooltipPerformanceMonitor, app.name));
 			}
 
 			browser.openURL(url);


### PR DESCRIPTION
Fixes #19

The app monitor and performance monitor pages had the same id for a project. Make sure the ids are unique.