### PR TITLE
Issue #124: Use the Codewind home page as the default url for Node.js debug

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/debug/NodeJsBrowserDialog.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/debug/NodeJsBrowserDialog.java
@@ -41,8 +41,9 @@ import org.eclipse.ui.internal.browser.IBrowserDescriptor;
 @SuppressWarnings("restriction")
 public class NodeJsBrowserDialog extends MessageDialog {
 	
-final String url;
+	public static final String DEFAULT_URL = "https://codewind.dev";
 	
+	final String url;
 	final String browserName;
 	
 	public NodeJsBrowserDialog(Shell parentShell, String dialogTitle,
@@ -106,7 +107,7 @@ final String url;
 		button.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
-				launchWebBrowser(browserName, "https://microclimate-dev2ops.github.io/");
+				launchWebBrowser(browserName, DEFAULT_URL);
 			}
 		});
 		


### PR DESCRIPTION
Fixes #124 

Use the Codewind home page as the default URL for Node.js debug.