### PR TITLE
Issue #136: Add trailing / to application metrics root

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectLanguage.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectLanguage.java
@@ -47,11 +47,11 @@ public enum ProjectLanguage {
 	public String getMetricsRoot() {
 		switch(this) {
 			case LANGUAGE_NODEJS:
-				return "appmetrics-dash";
+				return "appmetrics-dash/";
 			case LANGUAGE_SWIFT:
-				return "swiftmetrics-dash";
+				return "swiftmetrics-dash/";
 			case LANGUAGE_JAVA:
-				return "javametrics-dash";
+				return "javametrics-dash/";
 			default:
 				return null;
 		}


### PR DESCRIPTION
Update the root paths for application metrics to include a trailing /.