### PR TITLE
Ensure that path filters are applied to parent paths of a file change notification

### DIFF
--- a/dev/org.eclipse.codewind.filewatchers.eclipse/src/org/eclipse/codewind/filewatchers/eclipse/CodewindFilewatcherdConnection.java
+++ b/dev/org.eclipse.codewind.filewatchers.eclipse/src/org/eclipse/codewind/filewatchers/eclipse/CodewindFilewatcherdConnection.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
 import org.eclipse.codewind.filewatchers.JavaNioWatchService;
 import org.eclipse.codewind.filewatchers.core.FWLogger;
 import org.eclipse.codewind.filewatchers.core.Filewatcher;
@@ -92,6 +93,10 @@ public class CodewindFilewatcherdConnection {
 		}
 	}
 
+	/**
+	 * Called by the resource change listened with a list of changes, which we pass
+	 * along to the core file watcher.
+	 */
 	void handleResourceChanges(List<FileChangeEntryEclipse> result) {
 		if (result == null || result.size() == 0) {
 			return;

--- a/dev/org.eclipse.codewind.filewatchers.eclipse/src/org/eclipse/codewind/filewatchers/eclipse/CodewindFilewatcherdConnection.java
+++ b/dev/org.eclipse.codewind.filewatchers.eclipse/src/org/eclipse/codewind/filewatchers/eclipse/CodewindFilewatcherdConnection.java
@@ -94,7 +94,7 @@ public class CodewindFilewatcherdConnection {
 	}
 
 	/**
-	 * Called by the resource change listened with a list of changes, which we pass
+	 * Called by the resource change listener with a list of changes, which we pass
 	 * along to the core file watcher.
 	 */
 	void handleResourceChanges(List<FileChangeEntryEclipse> result) {

--- a/dev/org.eclipse.codewind.filewatchers.eclipse/src/org/eclipse/codewind/filewatchers/eclipse/CodewindResourceChangeListener.java
+++ b/dev/org.eclipse.codewind.filewatchers.eclipse/src/org/eclipse/codewind/filewatchers/eclipse/CodewindResourceChangeListener.java
@@ -42,10 +42,6 @@ public class CodewindResourceChangeListener implements IResourceChangeListener {
 		try {
 			delta.accept(visitor);
 
-			visitor.getResult().forEach(e -> {
-				System.out.println(e);
-			});
-
 			parent.handleResourceChanges(visitor.getResult());
 
 		} catch (CoreException e1) {
@@ -96,8 +92,9 @@ public class CodewindResourceChangeListener implements IResourceChangeListener {
 			}
 
 			if ((delta.getFlags() & IResourceDelta.CONTENT) == 0 && (delta.getFlags() & IResourceDelta.REPLACED) == 0) {
-				// Some workbench operations, such as adding/removing a debug breakpoint, will trigger a resource 
-				// delta, even though the actual file contents is the same. We ignore those, and return here.
+				// Some workbench operations, such as adding/removing a debug breakpoint, will
+				// trigger a resource delta, even though the actual file contents is the same. We ignore 
+				// those, and return here.
 				return true;
 			}
 

--- a/dev/org.eclipse.codewind.filewatchers.standalonenio/src/org/eclipse/codewind/filewatchers/JavaNioWatchService.java
+++ b/dev/org.eclipse.codewind.filewatchers.standalonenio/src/org/eclipse/codewind/filewatchers/JavaNioWatchService.java
@@ -319,6 +319,10 @@ public class JavaNioWatchService implements IPlatformWatchService {
 			});
 		}
 
+		/**
+		 * Wait for the watch path to become available, then wrap the main event loop
+		 * and prevent it from terminating the thread.
+		 */
 		private void eventLoopCatchAll() {
 
 			// Wait for the directory to exist, and be valid.


### PR DESCRIPTION
Fix is to use `splitRelativeProjectPathIntoComponentPaths` to check the change path (which I was already using to solve this issue in the Eclipse filewatcher project)