### PR TITLE
Issue #41: Remove app overview pages when connection is removed

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CoreUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CoreUtil.java
@@ -175,6 +175,17 @@ public class CoreUtil {
 	}
 	
 	/**
+	 * Remove the connection.  Apps must be passed in since they may not
+	 * be available if the connection is no longer active.
+	 */
+	public static void removeConnection(List<CodewindApplication> apps) {
+		IUpdateHandler handler = CodewindCorePlugin.getUpdateHandler();
+		if (handler != null) {
+			handler.removeConnection(apps);
+		}
+	}
+	
+	/**
 	 * Update the application in the Codewind explorer view
 	 */
 	public static void updateApplication(CodewindApplication app) {

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/IUpdateHandler.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/IUpdateHandler.java
@@ -11,6 +11,8 @@
 
 package org.eclipse.codewind.core.internal;
 
+import java.util.List;
+
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
 
 public interface IUpdateHandler {
@@ -20,6 +22,8 @@ public interface IUpdateHandler {
 	public void updateConnection(CodewindConnection connection);
 	
 	public void updateApplication(CodewindApplication application);
+	
+	public void removeConnection(List<CodewindApplication> apps);
 	
 	public void removeApplication(CodewindApplication application);
 

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnectionManager.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnectionManager.java
@@ -18,6 +18,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.codewind.core.CodewindCorePlugin;
+import org.eclipse.codewind.core.internal.CodewindApplication;
 import org.eclipse.codewind.core.internal.CodewindObjectFactory;
 import org.eclipse.codewind.core.internal.CoreUtil;
 import org.eclipse.codewind.core.internal.Logger;
@@ -97,7 +98,7 @@ public class CodewindConnectionManager {
 	}
 
 	/**
-	 * Try to remove the given connection. Removal will fail if the connection is still in use (ie. has a linked app).
+	 * Try to remove the given connection.
 	 * @return
 	 * 	true if the connection was removed,
 	 * 	false if not because it didn't exist.
@@ -107,16 +108,18 @@ public class CodewindConnectionManager {
 
 		CodewindConnection connection = CodewindConnectionManager.getActiveConnection(baseUrl.toString());
 		if (connection != null) {
+			List<CodewindApplication> apps = connection.getApps();
 			connection.close();
 			removeResult = instance().connections.remove(connection);
-		}
-		else {
+			CoreUtil.removeConnection(apps);
+		} else {
 			removeResult = instance().brokenConnections.remove(baseUrl);
 		}
 
 		if (!removeResult) {
 			Logger.logError("Tried to remove connection " + baseUrl + ", but it didn't exist"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
+		
 //		instance().writeToPreferences();
 		CoreUtil.updateAll();
 		return removeResult;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/UpdateHandler.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/UpdateHandler.java
@@ -12,6 +12,7 @@
 package org.eclipse.codewind.ui.internal.views;
 
 import java.util.HashMap;
+import java.util.List;
 
 import org.eclipse.codewind.core.internal.CodewindApplication;
 import org.eclipse.codewind.core.internal.IUpdateHandler;
@@ -49,6 +50,19 @@ public class UpdateHandler implements IUpdateHandler {
 		}
 	}
 	
+	@Override
+	public void removeConnection(List<CodewindApplication> apps) {
+		ViewHelper.refreshCodewindExplorerView(null);
+		synchronized(appListeners) {
+			for (CodewindApplication app : apps) {
+				AppUpdateListener listener = appListeners.get(app.projectID);
+				if (listener != null) {
+					listener.remove(app);
+				}
+			}
+		}
+	}
+
 	@Override
 	public void removeApplication(CodewindApplication app) {
 		ViewHelper.refreshCodewindExplorerView(app.connection);


### PR DESCRIPTION
Fixes #41 

If an application is removed then the overview page is already being cleaned up.  This PR fixes the case where the connection is removed (Codewind is stopped or uninstalled).