### PR TITLE
Issue #79: Show debug not supported for debug entries in overview as applicable

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
@@ -314,7 +314,13 @@ public class ApplicationOverviewEditorPart extends EditorPart {
 			locationEntry.setValue(app.fullLocalPath.toOSString(), true);
 			appURLEntry.setValue(app.isAvailable() && app.getRootUrl() != null ? app.getRootUrl().toString() : null, true);
 			hostAppPortEntry.setValue(app.isAvailable() && app.getHttpPort() > 0 ? Integer.toString(app.getHttpPort()) : null, true);
-			hostDebugPortEntry.setValue(app.isAvailable() && app.getDebugPort() > 0 ? Integer.toString(app.getDebugPort()) : null, true);
+			String hostDebugPort = null;
+			if (app.supportsDebug()) {
+				hostDebugPort = app.isAvailable() && app.getDebugPort() > 0 ? Integer.toString(app.getDebugPort()) : null;
+			} else {
+				hostDebugPort = Messages.AppOverviewEditorDebugNotSupported;
+			}
+			hostDebugPortEntry.setValue(hostDebugPort, true);
 			containerIdEntry.setValue(app.isAvailable() ? app.getContainerId() : null, true);
 			statusEntry.setValue(app.isAvailable(), true);
 		}
@@ -402,7 +408,13 @@ public class ApplicationOverviewEditorPart extends EditorPart {
 		public void update(CodewindApplication app) {
 			contextRootEntry.setValue(app.getContextRoot() != null ? app.getContextRoot() : "/", true); //$NON-NLS-1$
 			appPortEntry.setValue(app.getContainerAppPort(), true);
-			debugPortEntry.setValue(app.getContainerDebugPort(), true);
+			String debugPort = null;
+			if (app.supportsDebug()) {
+				debugPort = app.getContainerDebugPort();
+			} else {
+				debugPort = Messages.AppOverviewEditorDebugNotSupported;
+			}
+			debugPortEntry.setValue(debugPort, true);
 		}
 		
 		public void enableWidgets(boolean enable) {

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -244,6 +244,7 @@ public class Messages extends NLS {
 	public static String AppOverviewEditorImageNeverBuilt;
 	public static String AppOverviewEditorRefreshButton;
 	public static String AppOverviewEditorNotAvailable;
+	public static String AppOverviewEditorDebugNotSupported;
 	public static String AppOverviewEditorOpenSettingsErrorTitle;
 	public static String AppOverviewEditorOpenSettingsErrorMsg;
 	public static String AppOverviewEditorOpenSettingsNotFound;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -237,6 +237,7 @@ AppOverviewEditorProjectNeverBuilt=Project was never built
 AppOverviewEditorImageNeverBuilt=Image was never built
 AppOverviewEditorRefreshButton=Refresh
 AppOverviewEditorNotAvailable=Not available
+AppOverviewEditorDebugNotSupported=Debug not supported for this project type
 AppOverviewEditorOpenSettingsErrorTitle=Error Opening Project Settings
 AppOverviewEditorOpenSettingsErrorMsg=An error occurred while opening the project settings:\n\n{0}
 AppOverviewEditorOpenSettingsNotFound=The project settings file ''.cw-settings'' could not be found or was not accessible.


### PR DESCRIPTION
Fixes #79 

If debug is not supported, instead of showing "Not available" for debug ports in the overview page, show "Debug not supported for this project type" instead.