### PR TITLE
Issue #134: Check for contextRoot when updating application

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplicationFactory.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplicationFactory.java
@@ -230,13 +230,10 @@ public class CodewindApplicationFactory {
 			
 			// Set the context root
 			String contextRoot = null;
-			if (appJso.has(CoreConstants.KEY_CONTEXTROOT)) {
+			if (appJso.has(CoreConstants.KEY_CONTEXT_ROOT)) {
+				contextRoot = appJso.getString(CoreConstants.KEY_CONTEXT_ROOT);
+			} else if (appJso.has(CoreConstants.KEY_CONTEXTROOT)) {
 				contextRoot = appJso.getString(CoreConstants.KEY_CONTEXTROOT);
-			} else if (appJso.has(CoreConstants.KEY_CUSTOM)) {
-				JSONObject custom = appJso.getJSONObject(CoreConstants.KEY_CUSTOM);
-				if (custom.has(CoreConstants.KEY_CONTEXTROOT)) {
-					contextRoot = custom.getString(CoreConstants.KEY_CONTEXTROOT);
-				}
 			}
 			app.setContextRoot(contextRoot);
 			

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/CoreConstants.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/CoreConstants.java
@@ -49,7 +49,6 @@ public class CoreConstants {
 			KEY_CONTEXTROOT = "contextroot",
 			KEY_CONTEXT_ROOT = "contextRoot",
 			KEY_CONTAINER_ID = "containerId",
-			KEY_CUSTOM = "custom",
 
 			KEY_BUILD_LOG = "build-log",
 			KEY_BUILD_LOG_LAST_MODIFIED = "build-log-last-modified",


### PR DESCRIPTION
Fixes #134 

When application is updated check for "contextRoot" as well as the old "contextroot" in the json.  Remove the check for "custom": {"contextroot" as this is not used anymore.