### PR TITLE
Issue #148: Base debug on the project language instead of the project type

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
@@ -331,8 +331,8 @@ public class CodewindEclipseApplication extends CodewindApplication {
 
 	@Override
 	public boolean supportsDebug() {
-		// Only supported for certain project types
-		if (projectType == ProjectType.TYPE_LIBERTY || projectType == ProjectType.TYPE_SPRING || projectType == ProjectType.TYPE_NODEJS) {
+		// Only supported for certain languages
+		if (projectLanguage == ProjectLanguage.LANGUAGE_JAVA || projectLanguage == ProjectLanguage.LANGUAGE_NODEJS) {
 			// And only if the project supports it
 			ProjectCapabilities capabilities = getProjectCapabilities();
 			return (capabilities.supportsDebugMode() || capabilities.supportsDebugNoInitMode()) && capabilities.canRestart();


### PR DESCRIPTION
Fixes #148 

Base debug support on the project language rather than the project type.