### PR TITLE
Issue #65: Don't add empty describer element for .cwsettings content type

### DIFF
--- a/dev/org.eclipse.codewind.ui/plugin.xml
+++ b/dev/org.eclipse.codewind.ui/plugin.xml
@@ -345,7 +345,6 @@
 			name="%CW_SETTINGS_CONTENT_TYPE" 
 			base-type="org.eclipse.wst.json.core.jsonsource"
 			file-names=".cw-settings">
-			<describer class=""/>
 		</content-type>
 	</extension>
 


### PR DESCRIPTION
Fixes #65 

To not use the describer of the base type it should set the describer attribute to the empty string rather than add the describer element and set its class attribute to the empty string.  However it is probably better to use the describer of the base type so removed the describer element and everything is working properly now.