### PR TITLE
Issue #28: Add a shortcut for the new Codewind project wizard

### DIFF
--- a/dev/org.eclipse.codewind.ui/plugin.properties
+++ b/dev/org.eclipse.codewind.ui/plugin.properties
@@ -36,8 +36,8 @@ CODEWIND_VIEW_NAME=Codewind Explorer
 NAVIGATOR_CONTENT_NAME=Codewind Navigator Content
 NEW_CONNECTION_MENU_LABEL=Connection
 NEW_CONNECTION_DESCRIPTION=Create a connection to Codewind
-NEW_PROJECT_MENU_LABEL=Project
-NEW_PROJECT_DESCRIPTION=Create a new Codewind project
+NEW_PROJECT_MENU_LABEL=Codewind Project
+NEW_PROJECT_DESCRIPTION=Create a Codewind project
 
 DEFAULT_ICON_PATH=icons/codewind.ico
 RUN_ICON_PATH=icons/elcl16/launch_run.gif

--- a/dev/org.eclipse.codewind.ui/plugin.xml
+++ b/dev/org.eclipse.codewind.ui/plugin.xml
@@ -58,17 +58,7 @@
 			icon="%DEFAULT_ICON_PATH"
 			class="org.eclipse.codewind.ui.internal.views.CodewindExplorerView"/>
 	</extension>
-	
-	<extension point="org.eclipse.ui.perspectiveExtensions">
-		<perspectiveExtension 
-			targetID="org.eclipse.jst.j2ee.J2EEPerspective">
-	        <view id="org.eclipse.codewind.ui.explorerView" 
-	                relative="org.eclipse.wst.server.ui.ServersView" 
-	                relationship="stack"
-	                visible="true"/>
-		</perspectiveExtension> 
-	</extension>
-	
+
 	<extension point="org.eclipse.ui.navigator.viewer">
 		<viewerContentBinding
 			viewerId="org.eclipse.codewind.ui.explorerView">
@@ -346,6 +336,18 @@
 			base-type="org.eclipse.wst.json.core.jsonsource"
 			file-names=".cw-settings">
 		</content-type>
+	</extension>
+	
+	<extension point="org.eclipse.ui.perspectiveExtensions">
+		<perspectiveExtension 
+			targetID="org.eclipse.jst.j2ee.J2EEPerspective">
+	        <view id="org.eclipse.codewind.ui.explorerView" 
+	                relative="org.eclipse.wst.server.ui.ServersView" 
+	                relationship="stack"
+	                visible="true"/>
+	        <newWizardShortcut id="org.eclipse.codewind.ui.wizards.newProject"/>
+	        <viewShortcut id="org.eclipse.codewind.ui.explorerView"/>
+		</perspectiveExtension> 
 	</extension>
 
 </plugin>

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectWizard.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectWizard.java
@@ -31,8 +31,6 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.osgi.util.NLS;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.INewWizard;
 import org.eclipse.ui.IWorkbench;
 
@@ -61,31 +59,30 @@ public class NewCodewindProjectWizard extends Wizard implements INewWizard {
 
 	@Override
 	public void addPages() {
-		Display display = Display.getDefault();
-	    Shell result = display.getActiveShell();
-
 		try {
 			if (CodewindInstall.isCodewindInstalled()) {
-				 setWindowTitle(Messages.NewProjectPage_ShellTitle);
-				 newProjectPage = new NewCodewindProjectPage(connection, templateList);
-				 addPage(newProjectPage);
+				setWindowTitle(Messages.NewProjectPage_ShellTitle);
+				newProjectPage = new NewCodewindProjectPage(connection, templateList);
+				addPage(newProjectPage);
 			} else {
-				result.close();
 				CodewindInstall.codewindInstallerDialog();
+				if (getContainer() != null) {
+					getContainer().getShell().close();
+				}
 			}
 		} catch (InvocationTargetException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
- 
-		
 	}
 
 	@Override
 	public boolean performCancel() {
-		CodewindConnection newConnection = newProjectPage.getConnection();
-		if (newConnection != null && CodewindConnectionManager.getActiveConnection(newConnection.baseUrl.toString()) == null) {
-			newConnection.close();
+		if (newProjectPage != null) {
+			CodewindConnection newConnection = newProjectPage.getConnection();
+			if (newConnection != null && CodewindConnectionManager.getActiveConnection(newConnection.baseUrl.toString()) == null) {
+				newConnection.close();
+			}
 		}
 		return super.performCancel();
 	}


### PR DESCRIPTION
Fixes #28 

- Added a shortcut for the new Codewind project wizard.  This shows it in the Project Explorer view in the J2EE perspective if there are no projects yet.  It also puts it at the top level of the New Wizard menu for this perspective
- Added a shortcut for the Codewind Explorer view.  This puts it at the top level of the Window > Show View menu for the J2EE perspective so the user does not have to go to Other.
- Fixed a bug where if Codewind was not installed when the wizard is being launched it would try to close Eclipse