### PR TITLE
Issue #80: Don't show restart actions if not supported for the project type

### DIFF
--- a/dev/org.eclipse.codewind.ui/plugin.xml
+++ b/dev/org.eclipse.codewind.ui/plugin.xml
@@ -84,6 +84,10 @@
 				</or>
 			</enablement>
 			<actionProvider
+				id="org.eclipse.codewind.ui.rootActionProvider"
+				class="org.eclipse.codewind.ui.internal.actions.RootActionProvider">
+			</actionProvider>
+			<actionProvider
 				id="org.eclipse.codewind.ui.codewindActionProvider"
 				class="org.eclipse.codewind.ui.internal.actions.CodewindActionProvider">
 				<enablement>
@@ -154,20 +158,6 @@
 				label="%ACTION_IMPORT_PROJECT"
 				class="org.eclipse.codewind.ui.internal.actions.ImportProjectAction"/>
 			<action
-				id="org.eclipse.codewind.ui.restartDebugMode"
-				enablesFor="1"
-				menubarPath="group.generate"
-				icon="%DEBUG_ICON_PATH"
-				label="%ACTION_RESTART_DEBUG_MODE"
-				class="org.eclipse.codewind.ui.internal.actions.RestartDebugModeAction"/>
-			<action
-				id="org.eclipse.codewind.ui.restartRunMode"
-				enablesFor="1"
-				menubarPath="group.generate"
-				icon="%RUN_ICON_PATH"
-				label="%ACTION_RESTART_RUN_MODE"
-				class="org.eclipse.codewind.ui.internal.actions.RestartRunModeAction"/>
-			<action
 				id="org.eclipse.codewind.ui.enableDisableAutoBuild"
 				enablesFor="1"
 				menubarPath="group.build"
@@ -224,22 +214,6 @@
 		<viewContribution
 			id="org.eclipse.codewind.ui.explorerViewActions"
 			targetID="org.eclipse.codewind.ui.explorerView">
-			<action
-				id="org.eclipse.codewind.ui.restartRunModeAction"
-				label="%ACTION_RESTART_RUN_MODE"
-				menubarPath="group.top"
-				toolbarPath="group.top" 
-				icon="%RUN_ICON_PATH"
-				class="org.eclipse.codewind.ui.internal.actions.RestartRunModeAction">
-			</action>
-			<action
-				id="org.eclipse.codewind.ui.restartDebugModeAction"
-				label="%ACTION_RESTART_DEBUG_MODE"
-				menubarPath="group.top"
-				toolbarPath="group.top" 
-				icon="%DEBUG_ICON_PATH"
-				class="org.eclipse.codewind.ui.internal.actions.RestartDebugModeAction">
-			</action>
 			<action
 				id="org.eclipse.codewind.ui.openApplication"
 				label="%ACTION_OPEN_APP"

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/CodewindApplicationActionProvider.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/CodewindApplicationActionProvider.java
@@ -27,6 +27,8 @@ import org.eclipse.ui.navigator.ICommonMenuConstants;
 public class CodewindApplicationActionProvider extends CommonActionProvider {
 	
 //	private ValidateAction validateAction;
+	private RestartRunModeAction restartRunAction;
+	private RestartDebugModeAction restartDebugAction;
 	private AttachDebuggerAction attachDebuggerAction;
 	private OpenAppMonitorAction openAppMonitorAction;
 	private OpenPerfMonitorAction openPerfMonitorAction;
@@ -38,6 +40,8 @@ public class CodewindApplicationActionProvider extends CommonActionProvider {
         super.init(aSite);
         ISelectionProvider selProvider = aSite.getStructuredViewer();
 //        validateAction = new ValidateAction(selProvider);
+        restartRunAction = new RestartRunModeAction(selProvider);
+        restartDebugAction = new RestartDebugModeAction(selProvider);
         attachDebuggerAction = new AttachDebuggerAction(selProvider);
         openAppMonitorAction = new OpenAppMonitorAction(selProvider);
         openPerfMonitorAction = new OpenPerfMonitorAction(selProvider);
@@ -50,6 +54,12 @@ public class CodewindApplicationActionProvider extends CommonActionProvider {
 //    	if (validateAction.showAction()) {
 //    		menu.appendToGroup(ICommonMenuConstants.GROUP_BUILD, validateAction);
 //    	}
+    	if (restartRunAction.showAction()) {
+    		menu.appendToGroup(ICommonMenuConstants.GROUP_GENERATE, restartRunAction);
+    	}
+    	if (restartDebugAction.showAction()) {
+    		menu.appendToGroup(ICommonMenuConstants.GROUP_GENERATE, restartDebugAction);
+    	}
     	if (attachDebuggerAction.showAction()) {
     		menu.appendToGroup(ICommonMenuConstants.GROUP_GENERATE, attachDebuggerAction);
     	}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RootActionProvider.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RootActionProvider.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.codewind.ui.internal.actions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jface.action.ActionContributionItem;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.action.IContributionItem;
+import org.eclipse.jface.action.IContributionManager;
+import org.eclipse.jface.viewers.ISelectionProvider;
+import org.eclipse.ui.IActionBars;
+import org.eclipse.ui.navigator.CommonActionProvider;
+import org.eclipse.ui.navigator.ICommonActionExtensionSite;
+import org.eclipse.ui.navigator.ICommonMenuConstants;
+
+/**
+ * Action provider for the Codewind view.
+ */
+public class RootActionProvider extends CommonActionProvider {
+	
+	private RestartRunModeAction restartRunAction;
+	private RestartDebugModeAction restartDebugAction;
+	
+    @Override
+    public void init(ICommonActionExtensionSite aSite) {
+        super.init(aSite);
+        ISelectionProvider selProvider = aSite.getStructuredViewer();
+        restartRunAction = new RestartRunModeAction(selProvider);
+        restartDebugAction = new RestartDebugModeAction(selProvider);
+    }
+
+	@Override
+	public void fillActionBars(IActionBars actionBars) {
+		super.fillActionBars(actionBars);
+		actionBars.setGlobalActionHandler(RestartRunModeAction.ACTION_ID, restartRunAction);
+		actionBars.setGlobalActionHandler(RestartDebugModeAction.ACTION_ID, restartDebugAction);
+		
+		IContributionManager cm = actionBars.getToolBarManager();
+		IContributionItem[] items = cm.getItems();
+		List<IAction> existingActions = new ArrayList<IAction>();
+		for (IContributionItem item : items) {
+			if (item instanceof ActionContributionItem) {
+				existingActions.add(((ActionContributionItem)item).getAction());
+			}
+		}
+		if (!existingActions.contains(restartRunAction)) {
+			cm.appendToGroup(ICommonMenuConstants.GROUP_OPEN, restartRunAction);
+		}
+		if (!existingActions.contains(restartDebugAction)) {
+			cm.appendToGroup(ICommonMenuConstants.GROUP_OPEN, restartDebugAction);
+		}
+	}
+
+}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -122,8 +122,8 @@ SelectProjectPageDescription=Select the project to add to Codewind
 SelectProjectPageChooseProjectLabel=Choose the project to add:
 SelectProjectPageFilterText=Type filter text
 
-RestartInDebugMode=&Restart in Debug Mode
-RestartInRunMode=&Restart in Run Mode
+RestartInDebugMode=Restart in &Debug Mode
+RestartInRunMode=Restart in &Run Mode
 ErrorOnRestartDialogTitle=An error occurred restarting the project.
 
 EnableProjectLabel=&Enable Project


### PR DESCRIPTION
Fixes #80 

Only show the restart actions that are valid for the project type.  The toolbar restart actions will show all of the time but will be disabled if not supported by the project.