### PR TITLE
Issue #135: Allow open actions when app is in starting state

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
 import org.eclipse.codewind.core.internal.console.ProjectLogInfo;
-import org.eclipse.codewind.core.internal.constants.AppState;
+import org.eclipse.codewind.core.internal.constants.AppStatus;
 import org.eclipse.codewind.core.internal.constants.BuildStatus;
 import org.eclipse.codewind.core.internal.constants.CoreConstants;
 import org.eclipse.codewind.core.internal.constants.ProjectCapabilities;
@@ -42,7 +42,8 @@ public class CodewindApplication {
 	
 	private String contextRoot;	// can be null
 	private StartMode startMode;
-	private AppState appState;
+	private AppStatus appStatus;
+	private String appStatusDetails;
 	private BuildStatus buildStatus;
 	private String buildDetails;
 	private boolean autoBuild = true;
@@ -83,7 +84,7 @@ public class CodewindApplication {
 		this.fullLocalPath = CoreUtil.appendPathWithoutDupe(connection.getWorkspacePath(), pathInWorkspace);
 
 		this.startMode = StartMode.RUN;
-		this.appState = AppState.UNKNOWN;
+		this.appStatus = AppStatus.UNKNOWN;
 		this.buildStatus = BuildStatus.UNKOWN;
 	}
 
@@ -102,8 +103,15 @@ public class CodewindApplication {
 		}
 	}
 	
-	public synchronized void setAppStatus(String appStatus) {
-		this.appState = AppState.get(appStatus);
+	public synchronized void setAppStatus(String appStatus, String appStatusDetails) {
+		if (appStatus != null) {
+			this.appStatus = AppStatus.get(appStatus);
+			if (appStatusDetails == null || appStatusDetails.trim().isEmpty()) {
+				this.appStatusDetails = null;
+			} else {
+				this.appStatusDetails = appStatusDetails;
+			}
+		}
 	}
 	
 	public synchronized void setBuildStatus(String buildStatus, String buildDetails) {
@@ -225,8 +233,12 @@ public class CodewindApplication {
 		return null;
 	}
 	
-	public synchronized AppState getAppState() {
-		return appState;
+	public synchronized AppStatus getAppStatus() {
+		return appStatus;
+	}
+	
+	public synchronized String getAppStatusDetails() {
+		return appStatusDetails;
 	}
 	
 	public synchronized BuildStatus getBuildStatus() {
@@ -262,7 +274,7 @@ public class CodewindApplication {
 	}
 	
 	public boolean isActive() {
-		return getAppState() == AppState.STARTING || getAppState() == AppState.STARTED;
+		return getAppStatus() == AppStatus.STARTING || getAppStatus() == AppStatus.STARTED;
 	}
 
 	public boolean isRunning() {

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplicationFactory.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplicationFactory.java
@@ -152,9 +152,11 @@ public class CodewindApplicationFactory {
 			// Set the app status
 			if (appJso.has(CoreConstants.KEY_APP_STATUS)) {
 				String appStatus = appJso.getString(CoreConstants.KEY_APP_STATUS);
-				if (appStatus != null) {
-					app.setAppStatus(appStatus);
+				String detail = null;
+				if (appJso.has(CoreConstants.KEY_DETAILED_APP_STATUS)) {
+					detail = appJso.getString(CoreConstants.KEY_DETAILED_APP_STATUS);
 				}
+				app.setAppStatus(appStatus, detail);
 			}
 			
 			// Set the build status

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/AppStatus.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/AppStatus.java
@@ -14,38 +14,38 @@ package org.eclipse.codewind.core.internal.constants;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.messages.Messages;
 
-public enum AppState {
+public enum AppStatus {
 
-	STARTED	("started", Messages.AppStateStarted),
-	STARTING("starting", Messages.AppStateStarting),
-	STOPPING("stopping", Messages.AppStateStopping),
-	STOPPED	("stopped", Messages.AppStateStopped),
-	UNKNOWN	("unknown", Messages.AppStateUnknown);
+	STARTED	("started", Messages.AppStatusStarted),
+	STARTING("starting", Messages.AppStatusStarting),
+	STOPPING("stopping", Messages.AppStatusStopping),
+	STOPPED	("stopped", Messages.AppStatusStopped),
+	UNKNOWN	("unknown", Messages.AppStatusUnknown);
 
-	public final String appState;
+	public final String appStatus;
 	public final String displayString;
 
 	/**
-	 * @param appState - App state used by Codewind
+	 * @param appStatus - App state used by Codewind
 	 */
-	private AppState(String appState, String displayString) {
-		this.appState = appState;
+	private AppStatus(String appStatus, String displayString) {
+		this.appStatus = appStatus;
 		this.displayString = displayString;
 	}
 	
-	public static AppState get(String appState) {
-		for (AppState state : AppState.values()) {
-			if (state.appState.equals(appState)) {
+	public static AppStatus get(String appStatus) {
+		for (AppStatus state : AppStatus.values()) {
+			if (state.appStatus.equals(appStatus)) {
 				return state;
 			}
 		}
-		Logger.logError("Unrecognized application state: " + appState);
-		return AppState.UNKNOWN;
+		Logger.logError("Unrecognized application status: " + appStatus);
+		return AppStatus.UNKNOWN;
 	}
 
 	public String getDisplayString(StartMode mode) {
-		if (this == AppState.STARTED && StartMode.DEBUG_MODES.contains(mode)) {
-			return Messages.AppStateDebugging;
+		if (this == AppStatus.STARTED && StartMode.DEBUG_MODES.contains(mode)) {
+			return Messages.AppStatusDebugging;
 		}
 		return displayString;
 	}

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/CoreConstants.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/CoreConstants.java
@@ -69,6 +69,7 @@ public class CoreConstants {
 			KEY_RESULT = "result",
 			KEY_ERROR = "error",
 			KEY_APP_STATUS = "appStatus",
+			KEY_DETAILED_APP_STATUS = "detailedAppStatus",
 			KEY_BUILD_STATUS = "buildStatus",
 			KEY_DETAILED_BUILD_STATUS = "detailedBuildStatus",
 			KEY_LAST_BUILD = "lastbuild",

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
@@ -46,12 +46,12 @@ public class Messages extends NLS {
 	public static String Socket_ErrRestartingProjectDialogMsg;
 	public static String Socket_ErrRestartingProjectDialogTitle;
 	
-	public static String AppStateStarting;
-	public static String AppStateStarted;
-	public static String AppStateStopping;
-	public static String AppStateStopped;
-	public static String AppStateUnknown;
-	public static String AppStateDebugging;
+	public static String AppStatusStarting;
+	public static String AppStatusStarted;
+	public static String AppStatusStopping;
+	public static String AppStatusStopped;
+	public static String AppStatusUnknown;
+	public static String AppStatusDebugging;
 	
 	public static String BuildStateQueued;
 	public static String BuildStateInProgress;

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
@@ -39,12 +39,12 @@ FileNotFoundMsg=File {0} was not found.
 Socket_ErrRestartingProjectDialogMsg=The {0} project did not restart. Status: {1}\nTry disabling and re-enabling the project if the problem persists.
 Socket_ErrRestartingProjectDialogTitle=An error occurred while the project restarted
 
-AppStateStarting=Starting
-AppStateStarted=Running
-AppStateStopping=Stopping
-AppStateStopped=Stopped
-AppStateUnknown=No status information
-AppStateDebugging=Debugging
+AppStatusStarting=Starting
+AppStatusStarted=Running
+AppStatusStopping=Stopping
+AppStatusStopped=Stopped
+AppStatusUnknown=No status information
+AppStatusDebugging=Debugging
 
 BuildStateQueued=Build queued
 BuildStateInProgress=Building

--- a/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/BaseAutoBuildTest.java
+++ b/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/BaseAutoBuildTest.java
@@ -12,7 +12,7 @@
 package org.eclipse.codewind.test;
 
 import org.eclipse.codewind.core.internal.CodewindApplication;
-import org.eclipse.codewind.core.internal.constants.AppState;
+import org.eclipse.codewind.core.internal.constants.AppStatus;
 import org.eclipse.codewind.test.util.CodewindUtil;
 import org.eclipse.codewind.test.util.TestUtil;
 import org.eclipse.core.runtime.IPath;
@@ -53,8 +53,8 @@ public abstract class BaseAutoBuildTest extends BaseTest {
     	build();
     	CodewindApplication app = connection.getAppByName(projectName);
     	// For Java builds the states can go by quickly so don't do an assert on this
-    	CodewindUtil.waitForAppState(app, AppState.STOPPED, 120, 1);
-    	assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppState.STARTED, 120, 1));
+    	CodewindUtil.waitForAppState(app, AppStatus.STOPPED, 120, 1);
+    	assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppStatus.STARTED, 120, 1));
     	// Check for the new text
     	pingApp(text2);
     }
@@ -73,8 +73,8 @@ public abstract class BaseAutoBuildTest extends BaseTest {
     	// Check that build is started automatically
     	CodewindApplication app = connection.getAppByName(projectName);
     	// For Java builds the states can go by quickly so don't do an assert on this
-    	CodewindUtil.waitForAppState(app, AppState.STOPPED, 120, 1);
-    	assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppState.STARTED, 120, 1));
+    	CodewindUtil.waitForAppState(app, AppStatus.STOPPED, 120, 1);
+    	assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppStatus.STARTED, 120, 1));
     	// Check for the new text
     	pingApp(text3);
     }

--- a/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/BaseDebugTest.java
+++ b/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/BaseDebugTest.java
@@ -12,7 +12,7 @@
 package org.eclipse.codewind.test;
 
 import org.eclipse.codewind.core.internal.CodewindApplication;
-import org.eclipse.codewind.core.internal.constants.AppState;
+import org.eclipse.codewind.core.internal.constants.AppStatus;
 import org.eclipse.codewind.core.internal.constants.StartMode;
 import org.eclipse.codewind.test.util.CodewindUtil;
 import org.eclipse.codewind.test.util.TestUtil;
@@ -55,8 +55,8 @@ public abstract class BaseDebugTest extends BaseTest {
     	currentText = newText;
     	CodewindApplication app = connection.getAppByName(projectName);
     	// For Java builds the states can go by quickly so don't do an assert on this
-    	CodewindUtil.waitForAppState(app, AppState.STOPPED, 120, 1);
-    	assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppState.STARTED, 120, 1));
+    	CodewindUtil.waitForAppState(app, AppStatus.STOPPED, 120, 1);
+    	assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppStatus.STARTED, 120, 1));
     	pingApp(currentText);
     	checkMode(StartMode.DEBUG);
     	checkConsoles();
@@ -69,9 +69,9 @@ public abstract class BaseDebugTest extends BaseTest {
     	TestUtil.prependToFile(path.toOSString(), "# no comment\n");
     	refreshProject();
     	CodewindApplication app = connection.getAppByName(projectName);
-    	assertTrue("App should be in stopped state", CodewindUtil.waitForAppState(app, AppState.STOPPED, 120, 1));
-    	assertTrue("App should be in starting state", CodewindUtil.waitForAppState(app, AppState.STARTING, 600, 1));
-    	assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppState.STARTED, 300, 1));
+    	assertTrue("App should be in stopped state", CodewindUtil.waitForAppState(app, AppStatus.STOPPED, 120, 1));
+    	assertTrue("App should be in starting state", CodewindUtil.waitForAppState(app, AppStatus.STARTING, 600, 1));
+    	assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppStatus.STARTED, 300, 1));
     	pingApp(currentText);
     	checkMode(StartMode.DEBUG);
     	checkConsoles();

--- a/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/BaseTest.java
+++ b/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/BaseTest.java
@@ -27,7 +27,7 @@ import org.eclipse.codewind.core.internal.console.CodewindConsoleFactory;
 import org.eclipse.codewind.core.internal.console.ProjectLogInfo;
 import org.eclipse.codewind.core.internal.console.ProjectTemplateInfo;
 import org.eclipse.codewind.core.internal.console.SocketConsole;
-import org.eclipse.codewind.core.internal.constants.AppState;
+import org.eclipse.codewind.core.internal.constants.AppStatus;
 import org.eclipse.codewind.core.internal.constants.CoreConstants;
 import org.eclipse.codewind.core.internal.constants.ProjectLanguage;
 import org.eclipse.codewind.core.internal.constants.ProjectType;
@@ -119,7 +119,7 @@ public abstract class BaseTest extends TestCase {
     
     public void checkApp(String text) throws Exception {
     	CodewindApplication app = connection.getAppByName(projectName);
-    	assertTrue("App should be in started state.  Current state is: " + app.getAppState(), CodewindUtil.waitForAppState(app, AppState.STARTED, 120, 2));
+    	assertTrue("App should be in started state.  Current state is: " + app.getAppStatus(), CodewindUtil.waitForAppState(app, AppStatus.STARTED, 120, 2));
     	pingApp(text);
     	checkMode(StartMode.RUN);
     	showConsoles();
@@ -160,8 +160,8 @@ public abstract class BaseTest extends TestCase {
     	CodewindApplication app = connection.getAppByName(projectName);
     	connection.requestProjectRestart(app, mode.startMode);
     	// For Java builds the states can go by quickly so don't do an assert on this
-    	CodewindUtil.waitForAppState(app, AppState.STOPPED, 30, 1);
-    	assertTrue("App should be in started state instead of: " + app.getAppState(), CodewindUtil.waitForAppState(app, AppState.STARTED, 120, 1));
+    	CodewindUtil.waitForAppState(app, AppStatus.STOPPED, 30, 1);
+    	assertTrue("App should be in started state instead of: " + app.getAppStatus(), CodewindUtil.waitForAppState(app, AppStatus.STARTED, 120, 1));
     	checkMode(mode);
     }
     

--- a/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/NodeValidationTest.java
+++ b/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/NodeValidationTest.java
@@ -12,7 +12,7 @@
 package org.eclipse.codewind.test;
 
 import org.eclipse.codewind.core.internal.CodewindApplication;
-import org.eclipse.codewind.core.internal.constants.AppState;
+import org.eclipse.codewind.core.internal.constants.AppStatus;
 import org.eclipse.codewind.core.internal.constants.ProjectLanguage;
 import org.eclipse.codewind.core.internal.constants.ProjectType;
 import org.eclipse.codewind.test.util.CodewindUtil;
@@ -40,7 +40,7 @@ public class NodeValidationTest extends BaseValidationTest {
 		build();
 		CodewindApplication app = connection.getAppByName(projectName);
 		// For Java builds the states can go by quickly so don't do an assert on this
-		CodewindUtil.waitForAppState(app, AppState.STOPPED, 120, 1);
-		assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppState.STARTED, 300, 1));
+		CodewindUtil.waitForAppState(app, AppStatus.STOPPED, 120, 1);
+		assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppStatus.STARTED, 300, 1));
 	}
 }

--- a/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/util/CodewindUtil.java
+++ b/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/util/CodewindUtil.java
@@ -16,7 +16,7 @@ import java.util.List;
 import org.eclipse.codewind.core.internal.CodewindApplication;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
 import org.eclipse.codewind.core.internal.connection.CodewindConnectionManager;
-import org.eclipse.codewind.core.internal.constants.AppState;
+import org.eclipse.codewind.core.internal.constants.AppStatus;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -72,14 +72,14 @@ public class CodewindUtil {
 		CodewindConnectionManager.removeConnection(connection.baseUrl.toString());
 	}
 	
-	public static boolean waitForAppState(CodewindApplication app, AppState state, long timeout, long interval) {
+	public static boolean waitForAppState(CodewindApplication app, AppStatus status, long timeout, long interval) {
 		TestUtil.wait(new Condition() {
 			@Override
 			public boolean test() {
-				return app.getAppState() == state;
+				return app.getAppStatus() == status;
 			}
 		}, timeout, interval);
-		return app.getAppState() == state;
+		return app.getAppStatus() == status;
 	}
 
 }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/AttachDebuggerAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/AttachDebuggerAction.java
@@ -13,7 +13,7 @@ package org.eclipse.codewind.ui.internal.actions;
 
 import org.eclipse.codewind.core.internal.CodewindEclipseApplication;
 import org.eclipse.codewind.core.internal.Logger;
-import org.eclipse.codewind.core.internal.constants.AppState;
+import org.eclipse.codewind.core.internal.constants.AppStatus;
 import org.eclipse.codewind.core.internal.constants.ProjectLanguage;
 import org.eclipse.codewind.core.internal.constants.StartMode;
 import org.eclipse.codewind.ui.internal.messages.Messages;
@@ -47,7 +47,7 @@ public class AttachDebuggerAction extends SelectionProviderAction {
             		this.setText(Messages.AttachDebuggerLabel);
             	}
             	if (app.isAvailable() && StartMode.DEBUG_MODES.contains(app.getStartMode()) && app.getDebugPort() != -1 &&
-            			(app.getAppState() == AppState.STARTED || app.getAppState() == AppState.STARTING)) {
+            			(app.getAppStatus() == AppStatus.STARTED || app.getAppStatus() == AppStatus.STARTING)) {
             		setEnabled(app.canAttachDebugger());
             		return;
             	}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/OpenAppAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/OpenAppAction.java
@@ -16,7 +16,7 @@ import java.net.URL;
 import org.eclipse.codewind.core.internal.CodewindApplication;
 import org.eclipse.codewind.core.internal.CoreUtil;
 import org.eclipse.codewind.core.internal.Logger;
-import org.eclipse.codewind.core.internal.constants.AppState;
+import org.eclipse.codewind.core.internal.constants.AppStatus;
 import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.viewers.ISelection;
@@ -50,7 +50,7 @@ public class OpenAppAction implements IObjectActionDelegate, IViewActionDelegate
             Object obj = sel.getFirstElement();
             if (obj instanceof CodewindApplication) {
             	app = (CodewindApplication)obj;
-            	action.setEnabled(app.isAvailable() && app.getAppState() == AppState.STARTED);
+            	action.setEnabled(app.isAvailable() && (app.getAppStatus() == AppStatus.STARTING || app.getAppStatus() == AppStatus.STARTED));
             	return;
             }
         }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/OpenAppMonitorAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/OpenAppMonitorAction.java
@@ -16,7 +16,7 @@ import java.net.URL;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.CoreUtil;
 import org.eclipse.codewind.core.internal.CodewindApplication;
-import org.eclipse.codewind.core.internal.constants.AppState;
+import org.eclipse.codewind.core.internal.constants.AppStatus;
 import org.eclipse.codewind.core.internal.constants.CoreConstants;
 import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.jface.viewers.ISelectionProvider;
@@ -47,7 +47,7 @@ public class OpenAppMonitorAction extends SelectionProviderAction {
             Object obj = sel.getFirstElement();
             if (obj instanceof CodewindApplication) {
             	app = (CodewindApplication)obj;
-            	setEnabled(app.isAvailable() && app.getAppState() == AppState.STARTED);
+            	setEnabled(app.isAvailable() && (app.getAppStatus() == AppStatus.STARTING || app.getAppStatus() == AppStatus.STARTED));
             	return;
             }
         }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/OpenPerfMonitorAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/OpenPerfMonitorAction.java
@@ -16,7 +16,7 @@ import java.net.URL;
 import org.eclipse.codewind.core.internal.CodewindApplication;
 import org.eclipse.codewind.core.internal.CoreUtil;
 import org.eclipse.codewind.core.internal.Logger;
-import org.eclipse.codewind.core.internal.constants.AppState;
+import org.eclipse.codewind.core.internal.constants.AppStatus;
 import org.eclipse.codewind.core.internal.constants.CoreConstants;
 import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.jface.viewers.ISelectionProvider;
@@ -47,7 +47,7 @@ public class OpenPerfMonitorAction extends SelectionProviderAction {
             Object obj = sel.getFirstElement();
             if (obj instanceof CodewindApplication) {
             	app = (CodewindApplication)obj;
-            	setEnabled(app.isAvailable() && app.getAppState() == AppState.STARTED);
+            	setEnabled(app.isAvailable() && (app.getAppStatus() == AppStatus.STARTING || app.getAppStatus() == AppStatus.STARTED));
             	return;
             }
         }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RestartDebugModeAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RestartDebugModeAction.java
@@ -14,7 +14,7 @@ package org.eclipse.codewind.ui.internal.actions;
 import org.eclipse.codewind.core.internal.CodewindEclipseApplication;
 import org.eclipse.codewind.core.internal.CoreUtil;
 import org.eclipse.codewind.core.internal.Logger;
-import org.eclipse.codewind.core.internal.constants.AppState;
+import org.eclipse.codewind.core.internal.constants.AppStatus;
 import org.eclipse.codewind.core.internal.constants.ProjectLanguage;
 import org.eclipse.codewind.core.internal.constants.StartMode;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
@@ -56,7 +56,7 @@ public class RestartDebugModeAction extends SelectionProviderAction {
             if (obj instanceof CodewindEclipseApplication) {
             	app = (CodewindEclipseApplication)obj;
             	if (app.isAvailable() && app.supportsDebug()) {
-		            setEnabled(app.getAppState() == AppState.STARTED || app.getAppState() == AppState.STARTING);
+		            setEnabled(app.getAppStatus() == AppStatus.STARTED || app.getAppStatus() == AppStatus.STARTING);
 	            	return;
             	}
             }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RestartRunModeAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RestartRunModeAction.java
@@ -14,7 +14,7 @@ package org.eclipse.codewind.ui.internal.actions;
 import org.eclipse.codewind.core.internal.CodewindEclipseApplication;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.CoreUtil;
-import org.eclipse.codewind.core.internal.constants.AppState;
+import org.eclipse.codewind.core.internal.constants.AppStatus;
 import org.eclipse.codewind.core.internal.constants.StartMode;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.messages.Messages;
@@ -52,7 +52,7 @@ public class RestartRunModeAction extends SelectionProviderAction {
             if (obj instanceof CodewindEclipseApplication) {
             	app = (CodewindEclipseApplication)obj;
             	if (app.isAvailable() && app.getProjectCapabilities().canRestart()) {
-		            setEnabled(app.getAppState() == AppState.STARTED || app.getAppState() == AppState.STARTING);
+		            setEnabled(app.getAppStatus() == AppStatus.STARTED || app.getAppStatus() == AppStatus.STARTING);
 	            	return;
             	}
             }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -80,6 +80,7 @@ public class Messages extends NLS {
 	public static String CodewindDisconnected;
 	public static String CodewindProjectDisabled;
 	public static String CodewindConnectionNoProjects;
+	public static String CodewindDescriptionContextRoot;
 	
 	public static String InstallerActionInstallLabel;
 	public static String InstallerActionUninstallLabel;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -73,6 +73,7 @@ CodewindConnectionLabel=Codewind Connection:
 CodewindDisconnected=Disconnected. Right click and select Activate to start Codewind.
 CodewindProjectDisabled=Disabled
 CodewindConnectionNoProjects=No projects. Right click to create a new project or add an existing project.
+CodewindDescriptionContextRoot=Context root: {0}
 
 InstallerActionInstallLabel=&Install
 InstallerActionUninstallLabel=&Uninstall

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorLabelProvider.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorLabelProvider.java
@@ -14,7 +14,7 @@ package org.eclipse.codewind.ui.internal.views;
 import org.eclipse.codewind.core.internal.CodewindApplication;
 import org.eclipse.codewind.core.internal.CodewindManager;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
-import org.eclipse.codewind.core.internal.constants.AppState;
+import org.eclipse.codewind.core.internal.constants.AppStatus;
 import org.eclipse.codewind.core.internal.constants.BuildStatus;
 import org.eclipse.codewind.core.internal.constants.ProjectLanguage;
 import org.eclipse.codewind.core.internal.constants.ProjectType;
@@ -26,17 +26,19 @@ import org.eclipse.jface.viewers.DelegatingStyledCellLabelProvider.IStyledLabelP
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.StyledString;
 import org.eclipse.jface.viewers.StyledString.Styler;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.TextStyle;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.navigator.IDescriptionProvider;
 
 /**
  * Label provider for the Codewind view.
  */
-public class CodewindNavigatorLabelProvider extends LabelProvider implements IStyledLabelProvider {
+public class CodewindNavigatorLabelProvider extends LabelProvider implements IStyledLabelProvider, IDescriptionProvider {
 
 	static final Styler BOLD_FONT_STYLER = new BoldFontStyler();
 	
@@ -100,8 +102,8 @@ public class CodewindNavigatorLabelProvider extends LabelProvider implements ISt
 			StringBuilder builder = new StringBuilder(app.name);
 			
 			if (app.isEnabled()) {
-				AppState appState = app.getAppState();
-				String displayString = appState.getDisplayString(app.getStartMode());
+				AppStatus appStatus = app.getAppStatus();
+				String displayString = appStatus.getDisplayString(app.getStartMode());
 				builder.append(" [" + displayString + "]");
 				
 				BuildStatus buildStatus = app.getBuildStatus();
@@ -181,8 +183,8 @@ public class CodewindNavigatorLabelProvider extends LabelProvider implements ISt
 			styledString = new StyledString(app.name);
 			
 			if (app.isEnabled()) {
-				AppState appState = app.getAppState();
-				String displayString = appState.getDisplayString(app.getStartMode());
+				AppStatus appStatus = app.getAppStatus();
+				String displayString = appStatus.getDisplayString(app.getStartMode());
 				styledString.append(" [" + displayString + "]", StyledString.DECORATIONS_STYLER);
 				
 				BuildStatus buildStatus = app.getBuildStatus();
@@ -239,6 +241,19 @@ public class CodewindNavigatorLabelProvider extends LabelProvider implements ISt
 		}
 		return null;
 	}
+	
+    @Override
+    public String getDescription(Object element) {
+    	if (element instanceof CodewindApplication) {
+			CodewindApplication app = (CodewindApplication)element;
+			if (app.getAppStatusDetails() != null) {
+				return app.getAppStatusDetails();
+			} else if (app.getRootUrl() != null && (app.getAppStatus() == AppStatus.STARTING || app.getAppStatus() == AppStatus.STARTED)) {
+				return NLS.bind(Messages.CodewindDescriptionContextRoot, app.getRootUrl());
+			}
+    	}
+    	return null;
+    }
 
 	static class BoldFontStyler extends Styler {
 	    @Override


### PR DESCRIPTION
Fixes #135 

- Allow open app, open app monitor and open perf monitor actions when the application is in starting state
- Add description for the application when available
- Refactor AppState to AppStatus to be consistent with the API