### PR TITLE
Issue #156 - Handle resource change events with no resource delta object

### DIFF
--- a/dev/org.eclipse.codewind.filewatchers.eclipse/src/org/eclipse/codewind/filewatchers/eclipse/CodewindFilewatcherdConnection.java
+++ b/dev/org.eclipse.codewind.filewatchers.eclipse/src/org/eclipse/codewind/filewatchers/eclipse/CodewindFilewatcherdConnection.java
@@ -26,6 +26,15 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 
+/**
+ * This class is responsible for kicking off the Filewatcher core code (via the
+ * Filewatcher constructor), adding the resource change listener to workspace,
+ * and receiving events from that Eclipse resource change listener then passing
+ * those events to the core Filewatcher logic.
+ * 
+ * Only a single instance of this class should exist per Codewind server. This
+ * class is threadsafe.
+ */
 public class CodewindFilewatcherdConnection {
 
 	@SuppressWarnings("unused")
@@ -64,8 +73,10 @@ public class CodewindFilewatcherdConnection {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		workspace.addResourceChangeListener(listener);
 
+		// We use the native Eclipse-resource-listener-based watch service for projects
+		// inside the workspace, and the Java-NIO-JVM-based watch service for folders
+		// outside the workspace (eg the standalone Codewind settings directory).
 		this.platformWatchService = new EclipseResourceWatchService();
-
 		this.fileWatcher = new Filewatcher(url, clientUuid, platformWatchService, new JavaNioWatchService());
 
 		this.baseHttpUrl = url;
@@ -123,6 +134,13 @@ public class CodewindFilewatcherdConnection {
 
 	}
 
+	/**
+	 * The CodewindResourceChangeListener converts file/folder changes into
+	 * instances of this class, which are then converted to WatchEventEntry (above)
+	 * to be passed to the core Filewatcher plugin logic.
+	 * 
+	 * The main difference between this class and a WatchEventEntry is the IProject.
+	 */
 	public static class FileChangeEntryEclipse {
 
 		private final File f;

--- a/dev/org.eclipse.codewind.filewatchers.eclipse/src/org/eclipse/codewind/filewatchers/eclipse/CodewindResourceChangeListener.java
+++ b/dev/org.eclipse.codewind.filewatchers.eclipse/src/org/eclipse/codewind/filewatchers/eclipse/CodewindResourceChangeListener.java
@@ -26,9 +26,9 @@ import org.eclipse.core.resources.IResourceDeltaVisitor;
 import org.eclipse.core.runtime.CoreException;
 
 /**
- * An instance of this class is created by CodewindFilewatcherdConnection, is
- * also where where this class is registered as a workbench listener. Only one
- * instance of this class should exist per Codewind server.
+ * An instance of this class is created by CodewindFilewatcherdConnection, and
+ * is also where where this class is registered as a workbench listener. Only
+ * one instance of this class should exist per Codewind server.
  *
  * This class converts a list of changes from the IDE into a List of
  * FileChangeEntryEclipse, which are then processed by 'parent' and passed to
@@ -51,7 +51,7 @@ public class CodewindResourceChangeListener implements IResourceChangeListener {
 		try {
 
 			// If the delta is null (as happens with some events), just pass the empty array
-			// list.
+			// list below.
 			if (delta != null) {
 				delta.accept(visitor);
 			}

--- a/dev/org.eclipse.codewind.filewatchers.eclipse/src/org/eclipse/codewind/filewatchers/eclipse/CodewindResourceChangeListener.java
+++ b/dev/org.eclipse.codewind.filewatchers.eclipse/src/org/eclipse/codewind/filewatchers/eclipse/CodewindResourceChangeListener.java
@@ -25,6 +25,15 @@ import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IResourceDeltaVisitor;
 import org.eclipse.core.runtime.CoreException;
 
+/**
+ * An instance of this class is created by CodewindFilewatcherdConnection, is
+ * also where where this class is registered as a workbench listener. Only one
+ * instance of this class should exist per Codewind server.
+ *
+ * This class converts a list of changes from the IDE into a List of
+ * FileChangeEntryEclipse, which are then processed by 'parent' and passed to
+ * the Codewind core filewatcher plugin.
+ */
 public class CodewindResourceChangeListener implements IResourceChangeListener {
 
 	private final CodewindFilewatcherdConnection parent;
@@ -40,7 +49,12 @@ public class CodewindResourceChangeListener implements IResourceChangeListener {
 		CodewindResourceDeltaVisitor visitor = new CodewindResourceDeltaVisitor();
 
 		try {
-			delta.accept(visitor);
+
+			// If the delta is null (as happens with some events), just pass the empty array
+			// list.
+			if (delta != null) {
+				delta.accept(visitor);
+			}
 
 			parent.handleResourceChanges(visitor.getResult());
 
@@ -51,7 +65,11 @@ public class CodewindResourceChangeListener implements IResourceChangeListener {
 
 	}
 
-	private class CodewindResourceDeltaVisitor implements IResourceDeltaVisitor {
+	/**
+	 * A standard Eclipse resource delta visitor, which converts a list of workbench
+	 * resource changes into FileChangeEntryEclipse, for processing by 'parent'.
+	 */
+	private static class CodewindResourceDeltaVisitor implements IResourceDeltaVisitor {
 
 		private final List<FileChangeEntryEclipse> result = new ArrayList<>();
 
@@ -93,8 +111,8 @@ public class CodewindResourceChangeListener implements IResourceChangeListener {
 
 			if ((delta.getFlags() & IResourceDelta.CONTENT) == 0 && (delta.getFlags() & IResourceDelta.REPLACED) == 0) {
 				// Some workbench operations, such as adding/removing a debug breakpoint, will
-				// trigger a resource delta, even though the actual file contents is the same. We ignore 
-				// those, and return here.
+				// trigger a resource delta, even though the actual file contents is the same.
+				// We ignore those, and return here.
 				return true;
 			}
 


### PR DESCRIPTION
An event with a null resource delta object causes this issue:
https://github.com/eclipse/codewind-eclipse/issues/156