### PR TITLE
Issue #162: Remove logs on project closed event

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindSocket.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindSocket.java
@@ -419,6 +419,7 @@ public class CodewindSocket {
 			Logger.logError("No application found for project being closed: " + projectID); //$NON-NLS-1$
 			return;
 		}
+		app.dispose();
 		app.connection.refreshApps(app.projectID);
 		CoreUtil.updateApplication(app);
 	}


### PR DESCRIPTION
Fixes #162 

Call dispose on the application to remove logs and anything else related to the application (debug launch, etc.) when a project closed event is received (the application is disabled).