### PR TITLE
Issue #157: Show dialog if user tries to create or bind project while installer running

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/BindProjectAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/BindProjectAction.java
@@ -16,6 +16,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.TimeoutException;
 
 import org.eclipse.codewind.core.internal.CodewindManager;
+import org.eclipse.codewind.core.internal.CodewindManager.InstallerStatus;
 import org.eclipse.codewind.core.internal.CoreUtil;
 import org.eclipse.codewind.core.internal.InstallUtil;
 import org.eclipse.codewind.core.internal.InstallUtil.InstallStatus;
@@ -57,6 +58,18 @@ public class BindProjectAction implements IObjectActionDelegate {
 			Logger.logError("BindProjectAction ran but no project was selected"); //$NON-NLS-1$
 			return;
 		}
+
+		// If the installer is currently running, show a dialog to the user
+		final InstallerStatus installerStatus = CodewindManager.getManager().getInstallerStatus();
+		if (installerStatus != null) {
+			Display.getDefault().asyncExec(new Runnable() {
+				@Override
+				public void run() {
+					CodewindInstall.installerActiveDialog(installerStatus);
+				}
+			});
+			return;
+		}
 		
 		try {
 			if (CodewindInstall.isCodewindInstalled()) {
@@ -68,7 +81,7 @@ public class BindProjectAction implements IObjectActionDelegate {
 		} catch (InvocationTargetException e) {
 			Logger.logError("Error trying to set up Codewind to add existing project: " + project.getName(), e);
 		}
-		
+
 		if (connection == null || !connection.isConnected()) {
 			CoreUtil.openDialog(true, Messages.BindProjectErrorTitle, Messages.BindProjectConnectionError);
 			return;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/CodewindInstall.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/CodewindInstall.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.eclipse.codewind.core.CodewindCorePlugin;
 import org.eclipse.codewind.core.internal.CodewindManager;
+import org.eclipse.codewind.core.internal.CodewindManager.InstallerStatus;
 import org.eclipse.codewind.core.internal.InstallUtil;
 import org.eclipse.codewind.core.internal.InstallUtil.InstallStatus;
 import org.eclipse.codewind.core.internal.Logger;
@@ -79,6 +80,29 @@ public class CodewindInstall {
 				Messages.InstallCodewindDialogMessage)) {
 			installCodewind(addExistingProjectPrompt(project));
 		}
+	}
+	
+	public static void installerActiveDialog(InstallerStatus status) {
+		if (status == null) {
+			// This should not happen
+			Logger.logError("The installerActiveDialog method is invoked but the installer status is null");
+			return;
+		}
+		String msg = null;
+		switch(status) {
+			case INSTALLING:
+			case STARTING:
+				msg = Messages.InstallCodewindInstallingMessage;
+				break;
+			case UNINSTALLING:
+			case STOPPING:
+				msg = Messages.InstallCodewindUninstallingMessage;
+				break;
+			default:
+				Logger.logError("The installerActiveDialog method is invoked but the installer status is not recognized: " + status);
+				return;
+		}
+		MessageDialog.openError(Display.getDefault().getActiveShell(), Messages.InstallCodewindDialogTitle, msg);
 	}
 	
 	public static void installCodewind(Runnable prompt) { 
@@ -301,6 +325,9 @@ public class CodewindInstall {
 	private static IStatus getErrorStatus(ProcessResult result, String msg) {
 		Logger.logError("Installer failed with return code: " + result.getExitValue() + ", output: " + result.getOutput() + ", error: " + result.getError());
 		String errorText = result.getError() != null && !result.getError().isEmpty() ? result.getError() : result.getOutput();
+		if (errorText == null || errorText.trim().isEmpty()) {
+			errorText = NLS.bind(Messages.InstallCodewindFailNoMessage, result.getExitValue());
+		}
 		return getErrorStatus(msg + errorText, null);
 	}
 	

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -107,6 +107,9 @@ public class Messages extends NLS {
 	public static String InstallCodewindDialogMessage;
 	public static String InstallCodewindNewProjectMessage;
 	public static String InstallCodewindAddProjectMessage;
+	public static String InstallCodewindInstallingMessage;
+	public static String InstallCodewindUninstallingMessage;
+	public static String InstallCodewindFailNoMessage;
 	
 	public static String BindProjectErrorTitle;
 	public static String BindProjectConnectionError;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -109,6 +109,9 @@ InstallCodewindDialogTitle=Codewind Installer
 InstallCodewindDialogMessage=Codewind requires the installation of Docker containers to run, which might take a few minutes to download. Do you want to complete the installation now?
 InstallCodewindNewProjectMessage=Codewind installation is complete, do you want to create a new Codewind project?
 InstallCodewindAddProjectMessage=Codewind installation is complete, do you want to add the {0} project to Codewind?
+InstallCodewindInstallingMessage=Please wait for Codewind to be fully installed and running before trying to create or add projects.
+InstallCodewindUninstallingMessage=Projects cannot be created or added while Codewind is stopping or uninstalling.
+InstallCodewindFailNoMessage=The installer failed with error code {0}. Check logs for more information.
 
 SelectProjectTypePageName=Select Project Type
 SelectProjectTypePageTitle=Project Type and Language Selection

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectWizard.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectWizard.java
@@ -15,6 +15,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 import org.eclipse.codewind.core.internal.CodewindApplication;
+import org.eclipse.codewind.core.internal.CodewindManager;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
 import org.eclipse.codewind.core.internal.connection.CodewindConnectionManager;
@@ -64,6 +65,12 @@ public class NewCodewindProjectWizard extends Wizard implements INewWizard {
 				setWindowTitle(Messages.NewProjectPage_ShellTitle);
 				newProjectPage = new NewCodewindProjectPage(connection, templateList);
 				addPage(newProjectPage);
+			} else if (CodewindManager.getManager().getInstallerStatus() != null) {
+				// The installer is currently running
+				CodewindInstall.installerActiveDialog(CodewindManager.getManager().getInstallerStatus());
+				if (getContainer() != null) {
+					getContainer().getShell().close();
+				}
 			} else {
 				CodewindInstall.codewindInstallerDialog();
 				if (getContainer() != null) {


### PR DESCRIPTION
Fixed #157 

Improve the error handling if the user tries to create or bind a project while the installer is running.  Also added a message in case the installer fails without an error message.