### PR TITLE
Issue #194: Fix problems with context menu quick keys

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -80,7 +80,7 @@ InstallerActionUninstallLabel=&Uninstall
 InstallerActionStartLabel=&Start
 InstallerActionStopLabel=&Stop
 
-BindActionLabel=Add Existing Project...
+BindActionLabel=&Add Existing Project...
 UnbindActionLabel=R&emove
 UnbindActionTitle=Remove Projects
 UnbindActionMessage=Are you sure you want to remove project {0} from Codewind?
@@ -144,8 +144,8 @@ RestartInDebugMode=Restart in &Debug Mode
 RestartInRunMode=Restart in &Run Mode
 ErrorOnRestartDialogTitle=An error occurred restarting the project.
 
-EnableProjectLabel=&Enable Project
-DisableProjectLabel=&Disable Project
+EnableProjectLabel=Enable Pro&ject
+DisableProjectLabel=Disable Pro&ject
 EnableDisableProjectJob=Updating enablement for project: {0}
 ErrorOnEnableDisableProject=An error occurred while enabling or disabling project: {0}.
 
@@ -210,7 +210,7 @@ BrowserSelectionManageButtonText=Manage...
 BrowserSelectionListLabel=Web browser:
 BrowserSelectionNoBrowserSelected=No web browser selected
 
-NewProjectAction_Label=Create New &Project...
+NewProjectAction_Label=Create &New Project...
 NewProjectWizard_ShellTitle=New Codewind project
 NewProjectPage_ShellTitle=New Codewind project
 NewProjectPage_WizardDescription=Enter a project name and select a project template.


### PR DESCRIPTION
Fixes #194 

- Added quick key (A) for Add Existing Project
- Changed quick key for Create New Project to N from P
- Changed quick key for Enable Project and Disable Project to j (both do not show at the same time) to avoid collisions with other menu items