### PR TITLE
Issue #204: Allow tables to resize when the wizard is resized

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectPage.java
@@ -115,7 +115,7 @@ public class NewCodewindProjectPage extends WizardPage {
 	private void createContents(Composite parent) {
 		Composite composite = new Composite(parent, SWT.NONE);
 		composite.setLayout(new GridLayout(2, false));
-		composite.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false));
+		composite.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, true));
 		
 		Label label = new Label(composite, SWT.NONE);
 		label.setText(Messages.NewProjectPage_ProjectNameLabel);
@@ -140,7 +140,7 @@ public class NewCodewindProjectPage extends WizardPage {
 		layout.horizontalSpacing = 7;
 		layout.verticalSpacing = 7;
 		templateGroup.setLayout(layout);
-		templateGroup.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false, 2, 1));
+		templateGroup.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, true, 2, 1));
 		
 		// Filter text
 		filterText = new Text(templateGroup, SWT.BORDER);

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectSelectionPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectSelectionPage.java
@@ -73,7 +73,7 @@ public class ProjectSelectionPage extends WizardPage {
 		filterText.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 2, 1));
 		filterText.setMessage(Messages.SelectProjectPageFilterText);
         
-        CheckboxTableViewer projectList = CheckboxTableViewer.newCheckList(composite, SWT.BORDER);
+        CheckboxTableViewer projectList = CheckboxTableViewer.newCheckList(composite, SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
         projectList.setContentProvider(new WorkbenchContentProvider());
         projectList.setLabelProvider(new WorkbenchLabelProvider());
         projectList.setInput(ResourcesPlugin.getWorkspace().getRoot());

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectTypeSelectionPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectTypeSelectionPage.java
@@ -84,11 +84,11 @@ public class ProjectTypeSelectionPage extends WizardPage {
 		typeLabel.setBackground(composite.getBackground());
 		typeLabel.setForeground(composite.getForeground());
 		
-		typeViewer = CheckboxTableViewer.newCheckList(composite, SWT.BORDER);
+		typeViewer = CheckboxTableViewer.newCheckList(composite, SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
 		typeViewer.setContentProvider(ArrayContentProvider.getInstance());
 		typeViewer.setLabelProvider(new ProjectTypeLabelProvider());
 		typeViewer.setInput(getProjectTypeArray());
-		typeViewer.getTable().setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false));
+		typeViewer.getTable().setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, true));
 	   
 		languageLabel = new Text(composite, SWT.READ_ONLY);
 		languageLabel.setText(Messages.SelectProjectTypePageLanguageLabel);
@@ -96,10 +96,10 @@ public class ProjectTypeSelectionPage extends WizardPage {
 		languageLabel.setBackground(composite.getBackground());
 		languageLabel.setForeground(composite.getForeground());
 		
-		languageViewer = CheckboxTableViewer.newCheckList(composite, SWT.BORDER);
+		languageViewer = CheckboxTableViewer.newCheckList(composite, SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
 		languageViewer.setContentProvider(ArrayContentProvider.getInstance());
 		languageViewer.setLabelProvider(new LanguageLabelProvider());
-		languageViewer.getTable().setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false));
+		languageViewer.getTable().setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, true));
 		
 		typeViewer.addCheckStateListener(new ICheckStateListener() {
 			@Override


### PR DESCRIPTION
Fixes #204 

Allow the template table in the new project wizard and the tables in the add project wizard for selecting the type and language to grab excess vertical space.  Also added horizontal and vertical scroll to tables that did not have it.