### PR TITLE
CW Issue #274: Display Appsody for appsody project types instead of appsodyExtension

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
@@ -251,7 +251,7 @@ public class CodewindApplication {
 
 		// Only extension projects which report they DO support metrics require this extra check; 
 		// for normal projects the metricsAvailable is accurate.
-		if (!this.metricsAvailable || !this.projectType.getId().toLowerCase().contains("extension")) {
+		if (!this.metricsAvailable || !this.projectType.isExtension()) {
 			return;
 		}
 		

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplicationFactory.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplicationFactory.java
@@ -96,13 +96,17 @@ public class CodewindApplicationFactory {
 			// MCLogger.log("app: " + appJso.toString());
 			String name = appJso.getString(CoreConstants.KEY_NAME);
 			String id = appJso.getString(CoreConstants.KEY_PROJECT_ID);
+			JSONObject extension = null;
+			if (appJso.has(CoreConstants.KEY_EXTENSION)) {
+				extension = appJso.getJSONObject(CoreConstants.KEY_EXTENSION);
+			}
 
 			ProjectType type = ProjectType.TYPE_UNKNOWN;
 			ProjectLanguage language = ProjectLanguage.LANGUAGE_UNKNOWN;
 			try {
 				String typeStr = appJso.getString(CoreConstants.KEY_PROJECT_TYPE);
 				String languageStr = appJso.getString(CoreConstants.KEY_LANGUAGE);
-				type = ProjectType.getType(typeStr);
+				type = ProjectType.getType(typeStr, extension);
 				language = ProjectLanguage.getLanguage(languageStr);
 			} catch(JSONException e) {
 				Logger.logError(e.getMessage() + " in: " + appJso); //$NON-NLS-1$

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectInfo.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectInfo.java
@@ -17,7 +17,7 @@ public class ProjectInfo {
 	public final ProjectLanguage language;
 	
 	public ProjectInfo(String type, String language) {
-		this.type = ProjectType.getType(type);
+		this.type = ProjectType.getType(type, null);
 		this.language = ProjectLanguage.getLanguage(language);
 	}
 

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectType.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectType.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.codewind.core.internal.messages.Messages;
+import org.json.JSONObject;
 
 /**
  * Project type. For known types provides a user friendly name.
@@ -40,18 +41,36 @@ public class ProjectType {
 	
 	private final String typeId;
 	private final String displayName;
+	private final JSONObject extension;
 	
 	private ProjectType(String typeId, String displayName) {
-		this.typeId = typeId;
-		this.displayName = displayName;
+		this(typeId, displayName, null);
 	}
 	
-	public static ProjectType getType(String typeId) {
+	private ProjectType(String typeId, String displayName, JSONObject extension) {
+		this.typeId = typeId;
+		this.displayName = displayName;
+		this.extension = extension;
+	}
+	
+	public static ProjectType getType(String typeId, JSONObject extension) {
 		ProjectType type = defaultTypes.get(typeId);
 		if (type == null) {
-			type = new ProjectType(typeId, null);
+			String name = null;
+			if (extension != null) {
+				name = getExtDisplayName(typeId);
+			}
+			type = new ProjectType(typeId, name, extension);
 		}
 		return type;
+	}
+	
+	private static String getExtDisplayName(String typeId) {
+		String name = typeId.toLowerCase();
+		if (name.endsWith("extension")) {
+			name = name.substring(0, name.length() - "extension".length());
+		}
+		return name.substring(0, 1).toUpperCase() + name.substring(1);
 	}
 	
 	public String getId() {
@@ -65,6 +84,10 @@ public class ProjectType {
 		return typeId;
 	}
 	
+	public boolean isExtension() {
+		return extension != null;
+	}
+	
 	public static String getDisplayName(String typeId) {
 		if (typeId == null) {
 			return Messages.GenericUnknown;
@@ -73,7 +96,7 @@ public class ProjectType {
 		if (type != null) {
 			return type.getDisplayName();
 		}
-		return typeId;
+		return getExtDisplayName(typeId);
 	}
 	
  	public static ProjectType getTypeFromLanguage(String language) {


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/274

Display Appsody for appsody project types in the project overview page instead of appsodyExtension.