### PR TITLE
Issue #248: Improve the version checking to handle multiple levels

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
@@ -185,11 +185,32 @@ public class CodewindConnection {
 		}
 
 		try {
-			float version = Float.parseFloat(versionStr);
-			float expectedVersion = Float.parseFloat(InstallUtil.DEFAULT_INSTALL_VERSION);
-			return version >= expectedVersion;
-		}
-		catch(NumberFormatException e) {
+			String[] expectedDigits = InstallUtil.DEFAULT_INSTALL_VERSION.split("\\.");
+			String[] actualDigits = versionStr.split("\\.");
+			
+			for (int i = 0; i < expectedDigits.length; i++) {
+				int expectedVal = Integer.parseInt(expectedDigits[i]);
+				if (i >= actualDigits.length) {
+					// It is ok if the expected is longer than the actual
+					// as long as all of the extra digits are 0, if not
+					// then return false
+					if (expectedVal != 0) {
+						return false;
+					}
+				} else {
+					// If the value is less than expected, return false.
+					// If the value is greater than expected, return true.
+					// If they are the same, keep going.
+					int actualVal = Integer.parseInt(actualDigits[i]);
+					if (actualVal < expectedVal) {
+						return false;
+					} else if (actualVal > expectedVal) {
+						return true;
+					}
+				}
+			}
+			return true;
+		} catch(NumberFormatException e) {
 			Logger.logError("Couldn't parse version number from " + versionStr); //$NON-NLS-1$
 			return false;
 		}


### PR DESCRIPTION
Fixes #248 

The old version would only handle 2 levels such as 0.3.  Fix it to handle multiple levels such as 0.3.0.1.