### PR TITLE
Issue #254: Update version to 0.3.1 and include version checking fix

### DIFF
--- a/dev/ant_build/build-cw.xml
+++ b/dev/ant_build/build-cw.xml
@@ -10,7 +10,7 @@
 -->
 
 <project name="cw_build" default="generateOpenCWUpdateSite">
-    <property name="level_tag" value="0.3.0"/>
+    <property name="level_tag" value="0.3.1"/>
     <property name="delegate.build.dir" location="${basedir}/../" />
     <property name="disable.run.executeMetatypeValidation" value="true"/>
     <property name="disable.run.unzipIfixReleaseZip" value="true"/>

--- a/dev/org.eclipse.codewind.core/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Codewind
 Bundle-SymbolicName: org.eclipse.codewind.core;singleton:=true
-Bundle-Version: 1.1.5.qualifier
+Bundle-Version: 1.1.6.qualifier
 Bundle-Activator: org.eclipse.codewind.core.CodewindCorePlugin
 Bundle-Vendor: IBM
 Bundle-Localization: plugin

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/InstallUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/InstallUtil.java
@@ -62,7 +62,7 @@ public class InstallUtil {
 	private static final String STATUS_CMD = "status";
 	private static final String REMOVE_CMD = "remove";
 	
-	public static final String DEFAULT_INSTALL_VERSION = "0.3";
+	public static final String DEFAULT_INSTALL_VERSION = "0.3.1";
 	
 	private static final String TAG_OPTION = "-t";
 	private static final String JSON_OPTION = "-j";

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
@@ -185,12 +185,33 @@ public class CodewindConnection {
 		}
 
 		try {
-			float version = Float.parseFloat(versionStr);
-			float expectedVersion = Float.parseFloat(InstallUtil.DEFAULT_INSTALL_VERSION);
-			return version >= expectedVersion;
-		}
-		catch(NumberFormatException e) {
-			Logger.logError("Couldn't parse version number from " + versionStr); //$NON-NLS-1$
+			String[] expectedDigits = InstallUtil.DEFAULT_INSTALL_VERSION.split("\\.");
+			String[] actualDigits = versionStr.split("\\.");
+			
+			for (int i = 0; i < expectedDigits.length; i++) {
+				int expectedVal = Integer.parseInt(expectedDigits[i]);
+				if (i >= actualDigits.length) {
+					// It is ok if the expected is longer than the actual
+					// as long as all of the extra digits are 0, if not
+					// then return false
+					if (expectedVal != 0) {
+						return false;
+					}
+				} else {
+					// If the value is less than expected, return false.
+					// If the value is greater than expected, return true.
+					// If they are the same, keep going.
+					int actualVal = Integer.parseInt(actualDigits[i]);
+					if (actualVal < expectedVal) {
+						return false;
+					} else if (actualVal > expectedVal) {
+						return true;
+					}
+				}
+			}
+			return true;
+		} catch(NumberFormatException e) {
+			Logger.logError("Couldn't parse version number from: " + versionStr); //$NON-NLS-1$
 			return false;
 		}
 	}

--- a/dev/org.eclipse.codewind/feature.xml
+++ b/dev/org.eclipse.codewind/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.codewind"
       label="%featureName"
-      version="0.3.0.qualifier"
+      version="0.3.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.codewind.core">
 


### PR DESCRIPTION
Update the version and default install tag to 0.3.1.  Also include the version checking fix from PR: https://github.com/eclipse/codewind-eclipse/pull/249.