### PR TITLE
CW Issue #379: Increase install status timeout and only update when necessary

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/InstallUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/InstallUtil.java
@@ -125,6 +125,7 @@ public class InstallUtil {
 			if (process != null && process.isAlive()) {
 				process.destroy();
 			}
+			CodewindManager.getManager().refreshInstallStatus();
 			CodewindManager.getManager().setInstallerStatus(null);
 		}
 	}
@@ -141,6 +142,7 @@ public class InstallUtil {
 			if (process != null && process.isAlive()) {
 				process.destroy();
 			}
+			CodewindManager.getManager().refreshInstallStatus();
 			CodewindManager.getManager().setInstallerStatus(null);
 		}
 	}
@@ -157,6 +159,7 @@ public class InstallUtil {
 			if (process != null && process.isAlive()) {
 				process.destroy();
 			}
+			CodewindManager.getManager().refreshInstallStatus();
 			CodewindManager.getManager().setInstallerStatus(null);
 		}
 	}
@@ -177,6 +180,7 @@ public class InstallUtil {
 			if (process != null && process.isAlive()) {
 				process.destroy();
 			}
+			CodewindManager.getManager().refreshInstallStatus();
 			CodewindManager.getManager().setInstallerStatus(null);
 		}
 	}
@@ -248,7 +252,7 @@ public class InstallUtil {
 		Process process = null;
 		try {
 			process = runInstaller(STATUS_CMD, JSON_OPTION);
-			ProcessResult result = ProcessHelper.waitForProcess(process, 500, 60, new NullProgressMonitor());
+			ProcessResult result = ProcessHelper.waitForProcess(process, 500, 120, new NullProgressMonitor());
 			return result;
 		} finally {
 			if (process != null && process.isAlive()) {

--- a/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/BaseTest.java
+++ b/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/BaseTest.java
@@ -86,7 +86,7 @@ public abstract class BaseTest extends TestCase {
 	
     public void doSetup() throws Exception {
     	// Check that Codewind is installed
-    	assertTrue("Codewind must be installed and started before the tests can be run", CodewindManager.getManager().getInstallStatus(true).isStarted());
+    	assertTrue("Codewind must be installed and started before the tests can be run", CodewindManager.getManager().getInstallStatus().isStarted());
     	
     	// Disable workspace auto build
     	origAutoBuildSetting = setWorkspaceAutoBuild(false);

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/BindProjectAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/BindProjectAction.java
@@ -71,15 +71,11 @@ public class BindProjectAction implements IObjectActionDelegate {
 			return;
 		}
 		
-		try {
-			if (CodewindInstall.isCodewindInstalled()) {
-				connection = setupConnection();
-			} else {
-				CodewindInstall.codewindInstallerDialog(project);
-				return;
-			}
-		} catch (InvocationTargetException e) {
-			Logger.logError("Error trying to set up Codewind to add existing project: " + project.getName(), e);
+		if (CodewindManager.getManager().getInstallStatus().isInstalled()) {
+			connection = setupConnection();
+		} else {
+			CodewindInstall.codewindInstallerDialog(project);
+			return;
 		}
 
 		if (connection == null || !connection.isConnected()) {
@@ -163,7 +159,7 @@ public class BindProjectAction implements IObjectActionDelegate {
 		if (connection != null && connection.isConnected()) {
 			return connection;
 		}
-		InstallStatus status = manager.getInstallStatus(true);
+		InstallStatus status = manager.getInstallStatus();
 		if (status.isStarted()) {
 			return manager.createLocalConnection();
 		}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/CodewindActionProvider.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/CodewindActionProvider.java
@@ -54,7 +54,7 @@ public class CodewindActionProvider extends CommonActionProvider {
     		return;
     	}
     	selProvider.setSelection(selProvider.getSelection());
-    	InstallStatus status = CodewindManager.getManager().getInstallStatus(false);
+    	InstallStatus status = CodewindManager.getManager().getInstallStatus();
     	menu.appendToGroup(ICommonMenuConstants.GROUP_OPEN, installUninstallAction);
     	if (status.isStarted()) {
     		menu.appendToGroup(ICommonMenuConstants.GROUP_OPEN, startStopAction);
@@ -93,7 +93,7 @@ public class CodewindActionProvider extends CommonActionProvider {
 		@Override
 		public void run() {
 			if (manager != null) {
-				InstallStatus status = manager.getInstallStatus(false);
+				InstallStatus status = manager.getInstallStatus();
 				if (status.isStarted()) {
 					ViewHelper.toggleExpansion(manager);
 				} else if (status.isInstalled()) {

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/CodewindInstall.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/CodewindInstall.java
@@ -12,7 +12,6 @@
 package org.eclipse.codewind.ui.internal.actions;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.TimeoutException;
 
 import org.eclipse.codewind.core.CodewindCorePlugin;
@@ -43,25 +42,11 @@ import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-import org.json.JSONException;
 
 
 public class CodewindInstall {
 	
 	public static boolean ENABLE_STOP_APPS_OPTION = false;
-		
-	public static boolean isCodewindInstalled() throws InvocationTargetException {
-			try {
-				InstallStatus status = InstallUtil.getInstallStatus();
-				return status != null && status.isInstalled();
-			} catch (IOException e) {
-				throw new InvocationTargetException(e, "An error occurred trying to determine Codewind status: " + e.getMessage()); //$NON-NLS-1$
-			} catch (TimeoutException e) {
-				throw new InvocationTargetException(e, "Codewind did not return status in the expected time: " + e.getMessage()); //$NON-NLS-1$
-			} catch (JSONException e) {
-				throw new InvocationTargetException(e, "The Codewind status format is not recognized: " + e.getMessage()); //$NON-NLS-1$
-			}
-	}
 
 	public static void codewindInstallerDialog() {
 		codewindInstallerDialog(getNewProjectPrompt());
@@ -72,7 +57,7 @@ public class CodewindInstall {
 	}
 	
 	private static void codewindInstallerDialog(Runnable prompt) {
-		InstallStatus status = CodewindManager.getManager().getInstallStatus(false);
+		InstallStatus status = CodewindManager.getManager().getInstallStatus();
 		Shell shell = Display.getDefault().getActiveShell();
 		if (status.hasInstalledVersions()) {
 			if (MessageDialog.openQuestion(shell, Messages.InstallCodewindDialogTitle, Messages.UpgradeCodewindDialogMessage)) {
@@ -299,7 +284,7 @@ public class CodewindInstall {
 					SubMonitor mon = SubMonitor.convert(progressMon, 200);
 					try {
 						// Stop if necessary
-						InstallStatus status = InstallUtil.getInstallStatus();
+						InstallStatus status = CodewindManager.getManager().getInstallStatus();
 						if (status.hasStartedVersions()) {
 							mon.setTaskName(Messages.StoppingCodewindJobLabel);
 							try {
@@ -390,7 +375,7 @@ public class CodewindInstall {
 				protected IStatus run(IProgressMonitor progressMon) {
 			    	SubMonitor mon = SubMonitor.convert(progressMon, 100);
 					try {
-						InstallStatus status = InstallUtil.getInstallStatus();
+						InstallStatus status = CodewindManager.getManager().getInstallStatus();
 						if (status.isStarted()) {
 							// Stop Codewind before uninstalling
 							// All containers must be stopped or uninstall won't work
@@ -460,7 +445,7 @@ public class CodewindInstall {
 		ViewHelper.refreshCodewindExplorerView(null);
 		return new Status(IStatus.ERROR, CodewindUIPlugin.PLUGIN_ID, msg, t);
 	}
-	
+
 	private static boolean getStopAll(IProgressMonitor monitor) {
 		if (!ENABLE_STOP_APPS_OPTION) {
 			return true;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/InstallerAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/InstallerAction.java
@@ -51,7 +51,7 @@ public class InstallerAction extends SelectionProviderAction {
 		if (sel.size() == 1) {
 			Object obj = sel.getFirstElement();
 			if (obj instanceof CodewindManager) {
-				InstallStatus status = CodewindManager.getManager().getInstallStatus(false);
+				InstallStatus status = CodewindManager.getManager().getInstallStatus();
 				if (actionType == ActionType.INSTALL_UNINSTALL) {
 					if (status.isInstalled()) {
 						setText(actionType.disableLabel);
@@ -90,7 +90,7 @@ public class InstallerAction extends SelectionProviderAction {
 
 	@Override
 	public void run() {
-		InstallStatus status = CodewindManager.getManager().getInstallStatus(false);
+		InstallStatus status = CodewindManager.getManager().getInstallStatus();
 		if (actionType == ActionType.INSTALL_UNINSTALL) {
 			if (Messages.InstallerActionUpdateLabel.equals(getText())) {
 				boolean result = IDEUtil.openConfirmDialog(Messages.UpdateCodewindDialogTitle, Messages.UpdateCodewindDialogMsg);

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
@@ -99,7 +99,7 @@ public class ApplicationOverviewEditorPart extends EditorPart {
 	public void init(IEditorSite site, IEditorInput input) throws PartInitException {
 		CodewindApplication application = null;
 		if (input instanceof ApplicationOverviewEditorInput &&
-				CodewindManager.getManager().getInstallStatus(false).isStarted()) {
+				CodewindManager.getManager().getInstallStatus().isStarted()) {
 			ApplicationOverviewEditorInput appInput = (ApplicationOverviewEditorInput)input;
 			if (appInput.connectionUri != null && appInput.projectID != null) {
 				connection = CodewindConnectionManager.getActiveConnection(appInput.connectionUri);

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorContentProvider.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorContentProvider.java
@@ -60,7 +60,7 @@ public class CodewindNavigatorContentProvider implements ITreeContentProvider {
 	public boolean hasChildren(Object obj) {
 		if (obj instanceof CodewindManager) {
 			CodewindManager manager = (CodewindManager) obj;
-			if (manager.getInstallStatus(true).isStarted()) {
+			if (manager.getInstallStatus().isStarted()) {
 				// Make sure the local connection is there if Codewind is running
 				if (manager.getLocalConnection() == null) {
 					manager.createLocalConnection();

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorLabelProvider.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorLabelProvider.java
@@ -70,7 +70,7 @@ public class CodewindNavigatorLabelProvider extends LabelProvider implements ISt
 					return Messages.CodewindLabel + "[" + Messages.CodewindStoppingQualifier + "]";
 				}
 			} else {
-				InstallStatus status = manager.getInstallStatus(true);
+				InstallStatus status = manager.getInstallStatus();
 				if (status.isStarted()) {
 					return Messages.CodewindLabel + " [" + Messages.CodewindRunningQualifier + "]";
 				} else if (status.isInstalled()) {
@@ -154,7 +154,7 @@ public class CodewindNavigatorLabelProvider extends LabelProvider implements ISt
 					break;
 				}
 			} else {
-				InstallStatus status = manager.getInstallStatus(true);
+				InstallStatus status = manager.getInstallStatus();
 				if (status.isStarted()) {
 					styledString.append(" [" + Messages.CodewindRunningQualifier + "]", StyledString.DECORATIONS_STYLER);
 				} else if (status.isInstalled()) {

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindConnectionPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindConnectionPage.java
@@ -224,7 +224,7 @@ public class NewCodewindConnectionPage extends WizardPage {
 			@Override
 			public void run(IProgressMonitor monitor) throws InvocationTargetException {
 				try {
-					InstallStatus status = CodewindManager.getManager().getInstallStatus(false);
+					InstallStatus status = CodewindManager.getManager().getInstallStatus();
 					ProcessResult result = InstallUtil.startCodewind(status.getVersion(), monitor);
 					if (result.getExitValue() != 0) {
 						Logger.logError("Installer start failed with return code: " + result.getExitValue() + ", output: " + result.getOutput() + ", error: " + result.getError()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectPage.java
@@ -512,7 +512,7 @@ public class NewCodewindProjectPage extends WizardPage {
 		if (connection != null && connection.isConnected()) {
 			return;
 		}
-		InstallStatus status = manager.getInstallStatus(true);
+		InstallStatus status = manager.getInstallStatus();
 		if (status.isStarted()) {
 			connection = manager.createLocalConnection();
 			return;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectWizard.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectWizard.java
@@ -11,7 +11,6 @@
 
 package org.eclipse.codewind.ui.internal.wizards;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 import org.eclipse.codewind.core.internal.CodewindApplication;
@@ -63,26 +62,21 @@ public class NewCodewindProjectWizard extends Wizard implements INewWizard {
 
 	@Override
 	public void addPages() {
-		try {
-			if (CodewindInstall.isCodewindInstalled()) {
-				setWindowTitle(Messages.NewProjectPage_ShellTitle);
-				newProjectPage = new NewCodewindProjectPage(connection, templateList);
-				addPage(newProjectPage);
-			} else if (CodewindManager.getManager().getInstallerStatus() != null) {
-				// The installer is currently running
-				CodewindInstall.installerActiveDialog(CodewindManager.getManager().getInstallerStatus());
-				if (getContainer() != null) {
-					getContainer().getShell().close();
-				}
-			} else {
-				CodewindInstall.codewindInstallerDialog();
-				if (getContainer() != null) {
-					getContainer().getShell().close();
-				}
+		if (CodewindManager.getManager().getInstallerStatus() != null) {
+			// The installer is currently running
+			CodewindInstall.installerActiveDialog(CodewindManager.getManager().getInstallerStatus());
+			if (getContainer() != null) {
+				getContainer().getShell().close();
 			}
-		} catch (InvocationTargetException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+		} else if (CodewindManager.getManager().getInstallStatus().isInstalled()) {
+			setWindowTitle(Messages.NewProjectPage_ShellTitle);
+			newProjectPage = new NewCodewindProjectPage(connection, templateList);
+			addPage(newProjectPage);
+		} else {
+			CodewindInstall.codewindInstallerDialog();
+			if (getContainer() != null) {
+				getContainer().getShell().close();
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/379

Increase the install status timeout.

Install status was also being called too often so fixed it to only call when:
- Eclipse is started
- After install operations
- On a refresh