### PR TITLE
add dark mode as default for application monitor

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectLanguage.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectLanguage.java
@@ -47,11 +47,11 @@ public enum ProjectLanguage {
 	public String getMetricsRoot() {
 		switch(this) {
 			case LANGUAGE_NODEJS:
-				return "appmetrics-dash/";
+				return "appmetrics-dash/?theme=dark";
 			case LANGUAGE_SWIFT:
-				return "swiftmetrics-dash/";
+				return "swiftmetrics-dash/?theme=dark";
 			case LANGUAGE_JAVA:
-				return "javametrics-dash/";
+				return "javametrics-dash/?theme=dark";
 			default:
 				return null;
 		}


### PR DESCRIPTION
On click of application monitor on a project, goes to the dark-mode monitor to match the performance dashboard.

If the darkmode doesn't exist (i.e the version the metrics dashboard is not recent enough), this will just go to the standard light-mode.

(The same as https://github.com/eclipse/codewind-vscode/pull/188)

Signed-off-by: James Cockbain <james.cockbain@ibm.com>