### PR TITLE
Issue #285: Don't delete project contents until projectDeletion event received

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
@@ -60,6 +60,7 @@ public class CodewindApplication {
 	private long lastBuild = -1;
 	private long lastImageBuild = -1;
 	private boolean isHttps = false;
+	private boolean deleteContents = false;
 	
 
 	// Must be updated whenever httpPort changes. Can be null
@@ -410,6 +411,14 @@ public class CodewindApplication {
 	public synchronized boolean getIsHttps() {
 		return isHttps;
 	}
+	
+	public synchronized void setDeleteContents(boolean value) {
+		deleteContents = value;
+	}
+	
+	public synchronized boolean getDeleteContents() {
+		return deleteContents;
+	}
 
 	/**
 	 * Get the capabilities of a project.  Cache them because they should not change
@@ -456,6 +465,10 @@ public class CodewindApplication {
 	}
 	
 	public void validationWarning(String filePath, String message, String quickFixId, String quickFixDescription) {
+		// Override as needed
+	}
+	
+	public void onProjectDelete() {
 		// Override as needed
 	}
 	

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindSocket.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindSocket.java
@@ -18,10 +18,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.eclipse.codewind.core.internal.Logger;
-import org.eclipse.codewind.core.internal.CoreUtil;
 import org.eclipse.codewind.core.internal.CodewindApplication;
 import org.eclipse.codewind.core.internal.CodewindApplicationFactory;
+import org.eclipse.codewind.core.internal.CoreUtil;
+import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.console.ProjectLogInfo;
 import org.eclipse.codewind.core.internal.console.SocketConsole;
 import org.eclipse.codewind.core.internal.constants.CoreConstants;
@@ -431,6 +431,12 @@ public class CodewindSocket {
 
 	private void onProjectDeletion(JSONObject event) throws JSONException {
 		String projectID = event.getString(CoreConstants.KEY_PROJECT_ID);
+		CodewindApplication app = connection.getAppByID(projectID);
+		if (app == null) {
+			Logger.logError("No application found for project being deleted: " + projectID);
+			return;
+		}
+		app.onProjectDelete();
 		connection.removeApp(projectID);
 	}
 

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
@@ -73,6 +73,8 @@ public class Messages extends NLS {
 	public static String RemovingCodewindJobLabel;
 	public static String CreateProjectTaskLabel;
 	public static String ValidateProjectTaskLabel;
+	public static String DeleteProjectJobLabel;
+	public static String DeleteProjectError;
 	
 	public static String ProjectSettingsUpdateErrorTitle;
 	

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
@@ -66,6 +66,8 @@ StopCodewindJobLabel=Stopping Codewind
 RemovingCodewindJobLabel=Removing Codewind docker images
 CreateProjectTaskLabel=Creating project: {0}
 ValidateProjectTaskLabel=Validating project: {0}
+DeleteProjectJobLabel=Deleting project contents: {0}
+DeleteProjectError=An error occurred while trying to delete the contents of the {0} project.
 
 ProjectSettingsUpdateErrorTitle=Project settings update error
 

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/UnbindProjectAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/UnbindProjectAction.java
@@ -15,12 +15,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.codewind.core.internal.CodewindEclipseApplication;
-import org.eclipse.codewind.core.internal.FileUtil;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.messages.Messages;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -109,18 +106,14 @@ public class UnbindProjectAction extends SelectionProviderAction {
 				protected IStatus run(IProgressMonitor monitor) {
 					for (CodewindEclipseApplication app : apps) {
 						try {
+							app.setDeleteContents(deleteContent);
 							app.connection.requestProjectUnbind(app.projectID);
-							if (deleteContent) {
-								IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(app.name);
-								if (project != null && project.exists() && project.getLocation().toFile().equals(app.fullLocalPath.toFile())) {
-									project.delete(true, true, monitor);
-								} else if (app.fullLocalPath.toFile().exists()) {
-									FileUtil.deleteDirectory(app.fullLocalPath.toOSString(), true);
-								}
-							}
 						} catch (Exception e) {
 							Logger.logError("Error requesting application remove: " + app.name, e); //$NON-NLS-1$
 							return new Status(IStatus.ERROR, CodewindUIPlugin.PLUGIN_ID, NLS.bind(Messages.UnbindActionError, app.name), e);
+						}
+						if (monitor.isCanceled()) {
+							return Status.CANCEL_STATUS;
 						}
 					}
 					return Status.OK_STATUS;


### PR DESCRIPTION
Fixes #285 

Don't delete project contents until the projectDeletion event is received.