### PR TITLE
Add build date information in 'build_info.properties'

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,6 +59,7 @@ pipeline {
                             
                             scp $OUTPUT_DIR/$OUTPUT_NAME.zip $sshHost:$deployDir/$GIT_BRANCH/$LATEST_DIR/$OUTPUT_NAME.zip
                         
+                            echo "# Build date: $(date +%F-%T)" >> $OUTPUT_DIR/$BUILD_INFO
                             echo "build_info.url=$BUILD_URL" >> $OUTPUT_DIR/$BUILD_INFO
                             SHA1=$(sha1sum ${OUTPUT_DIR}/${OUTPUT_NAME}.zip | cut -d ' ' -f 1)
                             echo "build_info.SHA-1=${SHA1}" >> $OUTPUT_DIR/$BUILD_INFO


### PR DESCRIPTION
Build date information in 'build_info.properties' would be useful to clarify the correct latest build - the largest build id does not always mean the latest build. 

fixes https://github.com/eclipse/codewind/issues/89