### PR TITLE
CW Issue #460: Handle the case where the user has disabled all repositories

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
@@ -628,8 +628,12 @@ public class CodewindConnection {
 			uri = new URI(uri.getScheme(), uri.getAuthority(), uri.getPath(), query, uri.getFragment());
 		}
 		HttpResult result = HttpUtil.get(uri);
-		checkResult(result, uri, true);
+		checkResult(result, uri, false);
 		
+		// A response code of 204 means there are no available templates so just return the empty template list
+		if (result.responseCode == 204) {
+			return templates;
+		}
 		JSONArray templateArray = new JSONArray(result.response);
 		for (int i = 0; i < templateArray.length(); i++) {
 			templates.add(new ProjectTemplateInfo(templateArray.getJSONObject(i)));

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/CodewindConnectionActionProvider.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/CodewindConnectionActionProvider.java
@@ -28,6 +28,7 @@ public class CodewindConnectionActionProvider extends CommonActionProvider {
 	
 	private NewProjectAction newProjectAction;
 	private BindAction bindAction;
+	private ManageReposAction manageReposAction;
 	
 	@Override
 	public void init(ICommonActionExtensionSite aSite) {
@@ -35,6 +36,7 @@ public class CodewindConnectionActionProvider extends CommonActionProvider {
 		ISelectionProvider selProvider = aSite.getStructuredViewer();
 		newProjectAction = new NewProjectAction(selProvider);
 		bindAction = new BindAction(selProvider);
+		manageReposAction = new ManageReposAction(selProvider);
 	}
 	
 	@Override
@@ -51,6 +53,7 @@ public class CodewindConnectionActionProvider extends CommonActionProvider {
 			if (obj instanceof CodewindConnection) {
 				menu.appendToGroup(ICommonMenuConstants.GROUP_NEW, newProjectAction);
 				menu.appendToGroup(ICommonMenuConstants.GROUP_NEW, bindAction);
+				menu.appendToGroup(ICommonMenuConstants.GROUP_ADDITIONS, manageReposAction);
 			}
 		}
 	}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/ManageReposAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/ManageReposAction.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *	 IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.codewind.ui.internal.actions;
+
+import java.util.List;
+
+import org.eclipse.codewind.core.internal.Logger;
+import org.eclipse.codewind.core.internal.connection.CodewindConnection;
+import org.eclipse.codewind.core.internal.connection.RepositoryInfo;
+import org.eclipse.codewind.ui.CodewindUIPlugin;
+import org.eclipse.codewind.ui.internal.messages.Messages;
+import org.eclipse.codewind.ui.internal.prefs.RepositoryManagementDialog;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.viewers.ISelectionProvider;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.window.Window;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.actions.SelectionProviderAction;
+
+/**
+ * Action to create a new project.
+ */
+public class ManageReposAction extends SelectionProviderAction {
+
+	protected CodewindConnection connection;
+	
+	public ManageReposAction(ISelectionProvider selectionProvider) {
+		super(selectionProvider, Messages.RepoMgmtActionLabel);
+		setImageDescriptor(CodewindUIPlugin.getDefaultIcon());
+		selectionChanged(getStructuredSelection());
+	}
+
+
+	@Override
+	public void selectionChanged(IStructuredSelection sel) {
+		if (sel.size() == 1) {
+			Object obj = sel.getFirstElement();
+			if (obj instanceof CodewindConnection) {
+				connection = (CodewindConnection)obj;
+				setEnabled(connection.isConnected());
+				return;
+			}
+		}
+		setEnabled(false);
+	}
+
+	@Override
+	public void run() {
+		if (connection == null) {
+			// should not be possible
+			Logger.logError("ManageReposAction ran but no Codewind connection was selected"); //$NON-NLS-1$
+			return;
+		}
+		try {
+			List<RepositoryInfo> repoList = connection.requestRepositories();
+			RepositoryManagementDialog repoDialog = new RepositoryManagementDialog(Display.getDefault().getActiveShell(), connection, repoList);
+			if (repoDialog.open() == Window.OK && repoDialog.hasChanges()) {
+				Job job = new Job(Messages.RepoUpdateTask) {
+					@Override
+					protected IStatus run(IProgressMonitor monitor) {
+						return repoDialog.updateRepos(monitor);
+					}
+				};
+				job.schedule();
+			}
+		} catch (Exception e) {
+			MessageDialog.openError(Display.getDefault().getActiveShell(), Messages.RepoListErrorTitle, NLS.bind(Messages.RepoListErrorMsg, e));
+		}
+	}
+}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -157,6 +157,7 @@ public class Messages extends NLS {
 	public static String SelectProjectTypeRefreshTypesTask;
 	public static String SelectProjectTypeRefreshTypesError;
 	public static String SelectProjectTypeValidateTask;
+	public static String SelectProjectTypeNoProjectTypes;
 	
 	public static String SelectProjectPageName;
 	public static String SelectProjectPageTitle;
@@ -266,6 +267,7 @@ public class Messages extends NLS {
 	public static String NewProjectPage_ProjectCreateErrorMsg;
 	public static String NewProjectPage_CodewindConnectError;
 	public static String NewProjectPage_TemplateListError;
+	public static String NewProjectPage_EmptyTemplateList;
 	
 	public static String AppOverviewEditorCreateError;
 	public static String AppOverviewEditorPartName;
@@ -309,6 +311,8 @@ public class Messages extends NLS {
 	public static String GenericActionNotSupported;
 	public static String AppMonitorNotSupported;
 	public static String PerfDashboardNotSupported;
+	
+	public static String RepoMgmtActionLabel;
 	
 	public static String RepoMgmtDialogTitle;
 	public static String RepoMgmtDialogMessage;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -150,6 +150,7 @@ SelectProjectTypeManageRepoTooltip=Control the project types shown by adding, re
 SelectProjectTypeRefreshTypesTask=Refreshing project types
 SelectProjectTypeRefreshTypesError=An error occurred trying to get the updated list of project types.
 SelectProjectTypeValidateTask=Validating project: {0}
+SelectProjectTypeNoProjectTypes=There are no available project types. Use the Manage Repositories link to configure repositories and control the project types shown.
 
 SelectProjectPageName=Select Project
 SelectProjectPageTitle=Project Selection
@@ -259,6 +260,7 @@ NewProjectPage_ProjectCreateErrorTitle=Project Create Error
 NewProjectPage_ProjectCreateErrorMsg=An error occurred trying to create Codewind project {0}
 NewProjectPage_CodewindConnectError=Could not connect to Codewind. Check logs for more information.
 NewProjectPage_TemplateListError=Could not get the list of templates. Check logs for more information.
+NewProjectPage_EmptyTemplateList=There are no available templates. Use the Manage Repositories link to configure repositories and control the templates shown.
 
 AppOverviewEditorCreateError=The application overview editor could not be created for the input: {0}. Check the logs for more details.
 AppOverviewEditorPartName=Application Overview: {0}
@@ -302,6 +304,8 @@ StopAllDialog_ToggleMessage=Remember my choice and don't show this dialog again
 GenericActionNotSupported=Action not supported
 AppMonitorNotSupported=This project does not use AppMetrics, and so does not support the application monitor. 
 PerfDashboardNotSupported=This project does not use AppMetrics, and so does not support the performance dashboard.
+
+RepoMgmtActionLabel=&Manage Repositories
 
 RepoMgmtDialogTitle=Manage Repositories
 RepoMgmtDialogMessage=Add, remove, enable and disable repositories

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectPage.java
@@ -99,23 +99,28 @@ public class NewCodewindProjectPage extends WizardPage {
 		}
 		
 		if (templateList == null || templateList.isEmpty()) {
-			getTemplates();
-			if (templateList == null || templateList.isEmpty()) {
+			try {
+				templateList = connection.requestProjectTemplates(true);
+			} catch (Exception e) {
+				Logger.logError("An error occurred trying to get the list of templates", e); //$NON-NLS-1$
 				setErrorMessage(Messages.NewProjectPage_TemplateListError);
 				setControl(composite);
 				return;
 			}
 		}
 		
-		templateList.sort(new Comparator<ProjectTemplateInfo>() {
-			@Override
-			public int compare(ProjectTemplateInfo info1, ProjectTemplateInfo info2) {
-				return info1.getLabel().compareTo(info2.getLabel());
-			}
-		});
+		if (templateList.isEmpty()) {
+			setErrorMessage(Messages.NewProjectPage_EmptyTemplateList);
+		} else {
+			templateList.sort(new Comparator<ProjectTemplateInfo>() {
+				@Override
+				public int compare(ProjectTemplateInfo info1, ProjectTemplateInfo info2) {
+					return info1.getLabel().compareTo(info2.getLabel());
+				}
+			});
+		}
 
 		createContents(composite);
-
 		setControl(composite);
 	}
 
@@ -327,8 +332,11 @@ public class NewCodewindProjectPage extends WizardPage {
 	}
 
 	private boolean validate() {
+		if (templateList == null || templateList.isEmpty()) {
+			setErrorMessage(Messages.NewProjectPage_EmptyTemplateList);
+			return false;
+		}
 		String projectName = projectNameText.getText();
-		
 		if (projectName == null || projectName.isEmpty()) {
 			setErrorMessage(Messages.NewProjectPage_EmptyProjectName);
 			return false;
@@ -555,14 +563,6 @@ public class NewCodewindProjectPage extends WizardPage {
 		
 		if (connection == null) {
 			Logger.logError("Failed to connect to Codewind at: " + manager.getLocalURI()); //$NON-NLS-1$
-		}
-	}
-	
-	private void getTemplates() {
-		try {
-			templateList = connection.requestProjectTemplates(true);
-		} catch (Exception e) {
-			Logger.logError("An error occurred trying to get the list of templates", e); //$NON-NLS-1$
 		}
 	}
 }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectTypeSelectionPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectTypeSelectionPage.java
@@ -88,11 +88,14 @@ public class ProjectTypeSelectionPage extends WizardPage {
 		composite.setLayout(layout);
 		composite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		
-		if (typeMap == null || typeMap.isEmpty()) {
+		if (typeMap == null) {
 			Text errorLabel = new Text(composite, SWT.READ_ONLY | SWT.WRAP);
 			errorLabel.setText(Messages.SelectProjectTypeErrorLabel);
 			setControl(composite);
 			return;
+		}
+		if (typeMap.isEmpty()) {
+			setErrorMessage(Messages.SelectProjectTypeNoProjectTypes);
 		}
 		
 		typeLabel = new Text(composite, SWT.READ_ONLY);
@@ -348,7 +351,14 @@ public class ProjectTypeSelectionPage extends WizardPage {
 		if (typeViewer == null || typeViewer.getTable().isDisposed()) {
 			return;
 		}
-		typeViewer.setInput(getProjectTypeArray());
+		String[] projectTypes = getProjectTypeArray();
+		typeViewer.setInput(projectTypes);
+		if (projectTypes.length == 0) {
+			setErrorMessage(Messages.SelectProjectTypeNoProjectTypes);
+			updateLanguages(null, null);
+			return;
+		}
+		setErrorMessage(null);
 		if (type != null && typeMap.containsKey(type)) {
 			// Maintain the current selection
 			typeViewer.setCheckedElements(new Object[] {type});
@@ -415,8 +425,8 @@ public class ProjectTypeSelectionPage extends WizardPage {
 			return null;
 		}
 		if (templates == null || templates.isEmpty()) {
-			Logger.logError("Could not get the list of templates for connection: " + connection.baseUrl); //$NON-NLS-1$
-			return null;
+			Logger.log("The list of templates is empty for connection: " + connection.baseUrl); //$NON-NLS-1$
+			return typeMap;
 		}
 		for (ProjectTemplateInfo template : templates) {
 			Set<String> languages = typeMap.get(template.getProjectType());


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/460

Handle the case where the user has disabled all repositories.  The wizards will show an error and suggest the user click the Manage Repositories link to control the templates/project types shown.  An action has also been added on Projects (Local) to manage repositories.
