### PR TITLE
Issue #300: Use API for opening terminal and add app name to id

### DIFF
--- a/dev/org.eclipse.codewind.ui/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.ui/META-INF/MANIFEST.MF
@@ -19,9 +19,9 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.eclipse.codewind.ui;singleton:=true
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.codewind.ui.internal.actions
-Import-Package: org.eclipse.tm.terminal.view.core.interfaces.constants,
- org.eclipse.tm.terminal.view.ui.interfaces,
- org.eclipse.tm.terminal.view.ui.launcher,
+Import-Package: org.eclipse.tm.terminal.view.core,
+ org.eclipse.tm.terminal.view.core.interfaces,
+ org.eclipse.tm.terminal.view.core.interfaces.constants,
  org.eclipse.ui,
  org.eclipse.ui.console,
  org.eclipse.ui.forms,


### PR DESCRIPTION
Fixes #300 

- Use the API for opening a terminal into the application container
- Add the app name to the id so that it shows in the tab name as `Terminal <app name>` instead of just `Terminal`