### PR TITLE
CW Issue #469: when app is no longer in project list, perform full delete if requested

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
@@ -468,10 +468,6 @@ public class CodewindApplication {
 		// Override as needed
 	}
 	
-	public void onProjectDelete() {
-		// Override as needed
-	}
-	
 	public boolean supportsDebug() {
 		// Override as needed
 		return false;

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplicationFactory.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplicationFactory.java
@@ -79,6 +79,7 @@ public class CodewindApplicationFactory {
 			if (projectID == null) {
 				for (String id : connection.getAppIds()) {
 					if (!idSet.contains(id)) {
+						Logger.log("The application is no longer in the project list so removing: " + id);
 						connection.removeApp(id);
 					}
 				}

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
@@ -308,10 +308,11 @@ public class CodewindConnection {
 			app = appMap.remove(projectID);
 		}
 		if (app != null) {
+			Logger.log("Removing the " + app.name + " application with id: " + projectID);
 			CoreUtil.removeApplication(app);
 			app.dispose();
 		} else {
-			Logger.logError("No application found for project being deleted: " + projectID); //$NON-NLS-1$
+			Logger.log("No application found for deleted project: " + projectID); //$NON-NLS-1$
 		}
 	}
 

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindSocket.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindSocket.java
@@ -433,10 +433,9 @@ public class CodewindSocket {
 		String projectID = event.getString(CoreConstants.KEY_PROJECT_ID);
 		CodewindApplication app = connection.getAppByID(projectID);
 		if (app == null) {
-			Logger.logError("No application found for project being deleted: " + projectID);
+			Logger.log("No application found for project being deleted: " + projectID);
 			return;
 		}
-		app.onProjectDelete();
 		connection.removeApp(projectID);
 	}
 


### PR DESCRIPTION
The removal of an application may first be detected on an update of the project list, before the projectDeletion event is received.  Clean up the project at this point, including deleting the project contents if it was requested.

This fixes one part of https://github.com/eclipse/codewind/issues/469.  The problem deleting Maven based projects will be addressed in a separate PR.