### PR TITLE
Issue #307: Don't clear out language if project type changed

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectTypeSelectionPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectTypeSelectionPage.java
@@ -135,7 +135,19 @@ public class ProjectTypeSelectionPage extends WizardPage {
 				
 				String[] languages = getLanguageArray(type);
 				if (languages != null && languages.length > 1) {
-					language = null;
+					if (language != null) {
+						boolean found = false;
+						for (String lang : languages) {
+							if (language.equals(lang)) {
+								languageViewer.setCheckedElements(new Object[] {language});
+								found = true;
+								break;
+							}
+						}
+						if (!found) {
+							language = null;
+						}
+					}
 					languageLabel.setVisible(true);
 					languageViewer.setInput(languages);
 					languageViewer.getTable().setVisible(true);


### PR DESCRIPTION
Fixes #307 

Don't clear out the language if the project type changed and the language is valid for that project type.