### PR TITLE
Fix bug in CoreUtil.getEnvPath()

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CoreUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CoreUtil.java
@@ -85,7 +85,7 @@ public class CoreUtil {
 		String containerPath = hostPath;
 		if (isWindows() && hostPath.indexOf(':') == 1) { //$NON-NLS-1$
 			containerPath = "/" + hostPath.charAt(0) + hostPath.substring(2);
-			containerPath = containerPath.replaceAll("\\\\", "/"); //$NON-NLS-1$ //$NON-NLS-2$
+			containerPath = containerPath.replace("\\", "/"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		return containerPath;
 	}

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CoreUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CoreUtil.java
@@ -227,7 +227,7 @@ public class CoreUtil {
     		return null;
     	}
     	path = path.trim();
-    	path = path.replaceAll("\\", "/");
+    	path = path.replace("\\", "/");
     	if (!path.endsWith("/")) {
     		path = path + "/";
     	}

--- a/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/util/TestUtil.java
+++ b/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/util/TestUtil.java
@@ -133,7 +133,7 @@ public class TestUtil {
 		    }
 		
 		    String Content = stringbuilder.toString();
-		    String newContent = Content.replaceAll(originalString, replaceString);
+		    String newContent = Content.replace(originalString, replaceString);
 		    writer = new FileWriter(fileNeedsUpdate);
 		
 		    writer.write(newContent);


### PR DESCRIPTION
The statement

  path = path.replaceAll("\\\\", "/");

will produce a PatternSyntaxException because String.replaceAll()
expects a regex as it's first parameter, and "\\\\" is not a valid regex.
Fix is to change the call to String.replace()

Signed-off-by: John Pitman <jspitman@ca.ibm.com>