### PR TITLE
CW Issue #537: Fix minor issues with ProjectSelectionPage

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -179,6 +179,7 @@ public class Messages extends NLS {
 	public static String SelectProjectPageFilesystemDialogTitle;
 	public static String SelectProjectPageNoExistError;
 	public static String SelectProjectPageLocationError;
+	public static String SelectProjectPageCWProjectExistsError;
 	public static String SelectProjectPageProjectExistsError;
 	
 	public static String RestartInDebugMode;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -172,6 +172,7 @@ SelectProjectPageBrowseButton=Browse...
 SelectProjectPageFilesystemDialogTitle=Select a file system project in the Codewind workspace
 SelectProjectPageNoExistError=The selected path does not exist in the file system
 SelectProjectPageLocationError=Choose a project directly in the Codewind workspace folder: {0}
+SelectProjectPageCWProjectExistsError=A Codewind project already exists with the name: {0}
 SelectProjectPageProjectExistsError=A workspace project already exists with the name: {0}
 
 RestartInDebugMode=Restart in &Debug Mode

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectSelectionPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectSelectionPage.java
@@ -87,7 +87,7 @@ public class ProjectSelectionPage extends WizardPage {
 		if (hasValidProjects) {
 			// Filter text
 			filterText = new Text(composite, SWT.BORDER);
-			data = new GridData(SWT.FILL, SWT.FILL, true, false, 3, 1);
+			data = new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1);
 			data.horizontalIndent = 20;
 			filterText.setLayoutData(data);
 			filterText.setMessage(Messages.SelectProjectPageFilterText);
@@ -146,7 +146,7 @@ public class ProjectSelectionPage extends WizardPage {
 		} else {
 			noProjectsText = new Text(composite, SWT.READ_ONLY | SWT.WRAP);
 			noProjectsText.setText(NLS.bind(Messages.SelectProjectPageNoWorkspaceProjects, connection.getWorkspacePath().toOSString()));
-			data = new GridData(SWT.FILL, SWT.FILL, true, false, 3, 1);
+			data = new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1);
 			data.horizontalIndent = 20;
 			data.widthHint = 150;
 			noProjectsText.setLayoutData(data);
@@ -162,20 +162,20 @@ public class ProjectSelectionPage extends WizardPage {
 		
 		Label pathLabel = new Label(composite, SWT.NONE);
 		pathLabel.setText(Messages.SelectProjectPagePathLabel);
-		data = new GridData(SWT.FILL, SWT.FILL, false, false, 1, 1);
+		data = new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1);
 		data.horizontalIndent = 20;
 		pathLabel.setLayoutData(data);
 		
 		// Project path
 		pathText = new Text(composite, SWT.BORDER);
-		data = new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1);
+		data = new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1);
 		data.horizontalIndent = 20;
 		pathText.setLayoutData(data);
 		
 		// Browse button
 		Button browseButton = new Button(composite, SWT.PUSH);
 		browseButton.setText(Messages.SelectProjectPageBrowseButton);
-		data = new GridData(SWT.FILL, SWT.FILL, false, false, 1, 1);
+		data = new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1);
 		data.horizontalIndent = 20;
 		browseButton.setData(data);
 		
@@ -294,6 +294,10 @@ public class ProjectSelectionPage extends WizardPage {
 					if (relPath == null || relPath.isEmpty() || relPath.segmentCount() > 1) {
 						// The project should be directly in the Codewind workspace folder
 						errorMsg = NLS.bind(Messages.SelectProjectPageLocationError, connection.getWorkspacePath().toOSString());
+						projectPath = null;
+					} else if (connection.getAppByName(relPath.lastSegment()) != null) {
+						// It is an error if a Codewind project already exists with the same name
+						errorMsg = NLS.bind(Messages.SelectProjectPageCWProjectExistsError, relPath.lastSegment());
 						projectPath = null;
 					} else {
 						// It is an error if a project exists with the same name but has a different location


### PR DESCRIPTION
Fixes: https://github.com/eclipse/codewind/issues/537

Minor fixes to ProjectSelectionPage:

 -  Using FILL for vertical alignment on the MAC results in a huge text box that makes the text look really small.
 -  Also missed an error case where a Codewind project already exists with the same name.
