### PR TITLE
Rename binary to cwctl

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/InstallUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/InstallUtil.java
@@ -59,9 +59,9 @@ public class InstallUtil {
 	private static final Map<OperatingSystem, String> appsodyMap = new HashMap<OperatingSystem, String>();
 
 	static {
-		installMap.put(OperatingSystem.LINUX, "binaries/linux/codewind-installer");
-		installMap.put(OperatingSystem.MAC, "binaries/darwin/codewind-installer");
-		installMap.put(OperatingSystem.WINDOWS, "binaries/windows/codewind-installer.exe");
+		installMap.put(OperatingSystem.LINUX, "binaries/linux/cwctl");
+		installMap.put(OperatingSystem.MAC, "binaries/darwin/cwctl");
+		installMap.put(OperatingSystem.WINDOWS, "binaries/windows/cwctl.exe");
 	}
 	
 	static {


### PR DESCRIPTION
**Problem**
CLI binary name has been changed from codewind-installer -> cwctl. The plugin is pulling the old named binary.

**Solution**
Rename the binary in the plugin code

Signed-off-by: Liam Hampton <liam.hampton@ibm.com>