### PR TITLE
Hybrid: Improve connection error handling

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindManager.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindManager.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeoutException;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
 import org.eclipse.codewind.core.internal.connection.CodewindConnectionManager;
 import org.eclipse.codewind.core.internal.messages.Messages;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.json.JSONException;
 
 public class CodewindManager {
@@ -116,6 +117,7 @@ public class CodewindManager {
 		}
 		try {
 			CodewindConnection connection = CodewindObjectFactory.createCodewindConnection(Messages.CodewindLocalConnectionName, getLocalURI(), true);
+			connection.connect(new NullProgressMonitor());
 			localConnection = connection;
 			CodewindConnectionManager.add(connection);
 			return connection;

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindObjectFactory.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindObjectFactory.java
@@ -27,7 +27,7 @@ import org.eclipse.core.runtime.IPath;
  */
 public class CodewindObjectFactory {
 	
-	public static CodewindConnection createCodewindConnection(String name, URI uri, boolean isLocal) throws Exception {
+	public static CodewindConnection createCodewindConnection(String name, URI uri, boolean isLocal) {
 		return new CodewindConnection(name, uri, isLocal);
 	}
 	

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/HttpUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/HttpUtil.java
@@ -33,8 +33,8 @@ import okhttp3.Response;
  */
 public class HttpUtil {
 	
-	private static final int DEFAULT_READ_TIMEOUT_S = 10;
-	private static final int DEFAULT_READ_TIMEOUT_MS = DEFAULT_READ_TIMEOUT_S * 1000;
+	private static final int DEFAULT_CONNECT_TIMEOUT_MS = 10000;
+	private static final int DEFAULT_READ_TIMEOUT_MS = 10000;
 	
 	public static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
 	
@@ -118,130 +118,41 @@ public class HttpUtil {
 			return list.get(0);
 		}
 	}
-
+	
 	public static HttpResult get(URI uri) throws IOException {
-		HttpURLConnection connection = null;
+		return sendRequest("GET", uri, null);
+	}
 
-		try {
-			connection = (HttpURLConnection) uri.toURL().openConnection();
-
-			connection.setRequestMethod("GET");
-			connection.setReadTimeout(DEFAULT_READ_TIMEOUT_MS);
-
-			return new HttpResult(connection);
-		} finally {
-			if (connection != null) {
-				connection.disconnect();
-			}
-		}
+	public static HttpResult get(URI uri, int connectTimeoutMS, int readTimeoutMS) throws IOException {
+		return sendRequest("GET", uri, null, connectTimeoutMS, readTimeoutMS);
 	}
 	
-	/**
-	 * Post to the given URI passing along the payload.  The default value is used
-	 * for the read timeout.
-	 */
 	public static HttpResult post(URI uri, JSONObject payload) throws IOException {
-		return post(uri, payload, DEFAULT_READ_TIMEOUT_S);
+		return sendRequest("POST", uri, payload, DEFAULT_CONNECT_TIMEOUT_MS, DEFAULT_READ_TIMEOUT_MS);
 	}
 
-	public static HttpResult post(URI uri, JSONObject payload, int readTimoutSeconds) throws IOException {
-		return sendPayload("POST", uri, payload, DEFAULT_READ_TIMEOUT_S);
+	public static HttpResult post(URI uri, JSONObject payload, int readTimeoutSeconds) throws IOException {
+		return sendRequest("POST", uri, payload, DEFAULT_CONNECT_TIMEOUT_MS, readTimeoutSeconds * 1000);
 	}
 	
-	/**
-	 * POST/PUT to the given URI passing along the payload.  The readTimeout is in seconds.
-	 */
-	public static HttpResult sendPayload(String method, URI uri, JSONObject payload, int readTimoutSeconds) throws IOException {
-		HttpURLConnection connection = null;
-
-		Logger.log(method + " " + payload.toString() + " TO " + uri);
-		try {
-			connection = (HttpURLConnection) uri.toURL().openConnection();
-
-			connection.setRequestMethod(method);
-			connection.setReadTimeout(readTimoutSeconds * 1000);
-			
-			if (payload != null) {
-				connection.setRequestProperty("Content-Type", "application/json");
-				connection.setDoOutput(true);
-	
-				DataOutputStream payloadStream = new DataOutputStream(connection.getOutputStream());
-				payloadStream.write(payload.toString().getBytes());
-			}
-
-			return new HttpResult(connection);
-		} finally {
-			if (connection != null) {
-				connection.disconnect();
-			}
-		}
-	}
-
 	public static HttpResult post(URI uri) throws IOException {
-		HttpURLConnection connection = null;
-
-		Logger.log("Empty POST TO " + uri);
-		try {
-			connection = (HttpURLConnection) uri.toURL().openConnection();
-			connection.setRequestMethod("POST");
-			connection.setReadTimeout(DEFAULT_READ_TIMEOUT_MS);
-			return new HttpResult(connection);
-		} finally {
-			if (connection != null) {
-				connection.disconnect();
-			}
-		}
+		return sendRequest("POST", uri, null);
 	}
 
-	/**
-	 * Put to the given URI passing along the payload.  The default value is used
-	 * for the read timeout.
-	 */
-	public static HttpResult put(URI uri, JSONObject payload) throws IOException {
-		return put(uri, payload, DEFAULT_READ_TIMEOUT_S);
-	}
-
-	/**
-	 * Put to the given URI passing along the payload.  The readTimeout is in seconds.
-	 */
-	public static HttpResult put(URI uri, JSONObject payload, int readTimoutSeconds) throws IOException {
-		return sendPayload("PUT", uri, payload, DEFAULT_READ_TIMEOUT_S);
+	public static HttpResult put(URI uri) throws IOException {
+		return sendRequest("PUT", uri, null);
 	}
 	
-	public static HttpResult put(URI uri) throws IOException {
-		HttpURLConnection connection = null;
-
-		Logger.log("Empty PUT TO " + uri);
-		try {
-			connection = (HttpURLConnection) uri.toURL().openConnection();
-
-			connection.setRequestMethod("PUT");
-			connection.setReadTimeout(DEFAULT_READ_TIMEOUT_MS);
-
-			return new HttpResult(connection);
-		} finally {
-			if (connection != null) {
-				connection.disconnect();
-			}
-		}
+	public static HttpResult put(URI uri, JSONObject payload) throws IOException {
+		return sendRequest("PUT", uri, payload, DEFAULT_CONNECT_TIMEOUT_MS, DEFAULT_READ_TIMEOUT_MS);
+	}
+	
+	public static HttpResult put(URI uri, JSONObject payload, int readTimoutSeconds) throws IOException {
+		return sendRequest("PUT", uri, payload, DEFAULT_CONNECT_TIMEOUT_MS, DEFAULT_READ_TIMEOUT_MS);
 	}
 
 	public static HttpResult head(URI uri) throws IOException {
-		HttpURLConnection connection = null;
-
-		Logger.log("HEAD " + uri);
-		try {
-			connection = (HttpURLConnection) uri.toURL().openConnection();
-
-			connection.setRequestMethod("HEAD");
-			connection.setReadTimeout(DEFAULT_READ_TIMEOUT_MS);
-
-			return new HttpResult(connection);
-		} finally {
-			if (connection != null) {
-				connection.disconnect();
-			}
-		}
+		return sendRequest("HEAD", uri, null);
 	}
 	
 	public static HttpResult delete(URI uri) throws IOException {
@@ -249,14 +160,27 @@ public class HttpUtil {
 	}
 	
 	public static HttpResult delete(URI uri, JSONObject payload) throws IOException {
+		return sendRequest("DELETE", uri, payload);
+	}
+	
+	public static HttpResult sendRequest(String method, URI uri, JSONObject payload) throws IOException {
+		return sendRequest(method, uri, payload, DEFAULT_CONNECT_TIMEOUT_MS, DEFAULT_READ_TIMEOUT_MS);
+	}
+	
+	public static HttpResult sendRequest(String method, URI uri, JSONObject payload, int connectTimeoutMS, int readTimeoutMS) throws IOException {
 		HttpURLConnection connection = null;
+		if (payload != null) {
+			Logger.log("Making a " + method + " request on " + uri + " with payload: " + payload.toString());
+		} else {
+			Logger.log("Making a " + method + " request on " + uri);
+		}
 
-		Logger.log("DELETE " + uri);
 		try {
 			connection = (HttpURLConnection) uri.toURL().openConnection();
 
-			connection.setRequestMethod("DELETE");
-			connection.setReadTimeout(DEFAULT_READ_TIMEOUT_MS);
+			connection.setRequestMethod(method);
+			connection.setConnectTimeout(connectTimeoutMS);
+			connection.setReadTimeout(readTimeoutMS);
 			
 			if (payload != null) {
 				connection.setRequestProperty("Content-Type", "application/json");
@@ -273,7 +197,7 @@ public class HttpUtil {
 			}
 		}
 	}
-	
+
 	public static HttpResult patch(URI uri, JSONArray payload) throws IOException {
 		Logger.log("PATCH " + uri);
 		

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
@@ -46,6 +46,9 @@ import org.eclipse.codewind.core.internal.constants.ProjectType;
 import org.eclipse.codewind.core.internal.messages.Messages;
 import org.eclipse.codewind.filewatchers.eclipse.CodewindFilewatcherdConnection;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.osgi.util.NLS;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -69,7 +72,7 @@ public class CodewindConnection {
 	private CodewindSocket socket;
 	private CodewindFilewatcherdConnection filewatcher;
 	
-	private volatile boolean isConnected = true;
+	private volatile boolean isConnected = false;
 
 	private Map<String, CodewindApplication> appMap = new LinkedHashMap<String, CodewindApplication>();
 
@@ -77,7 +80,7 @@ public class CodewindConnection {
 		return new URI("http", null, host, port, null, null, null); //$NON-NLS-1$
 	}
 
-	public CodewindConnection(String name, URI uri, boolean isLocal) throws IOException, URISyntaxException, JSONException {
+	public CodewindConnection(String name, URI uri, boolean isLocal) {
 		this.name = name;
 		if (!uri.toString().endsWith("/")) { //$NON-NLS-1$
 			uri = uri.resolve("/"); //$NON-NLS-1$
@@ -85,12 +88,6 @@ public class CodewindConnection {
 		this.baseUrl = uri;
 		this.isLocal = isLocal;
 
-		if (CodewindConnectionManager.getActiveConnection(uri.toString()) != null) {
-			onInitFail(NLS.bind(Messages.Connection_ErrConnection_AlreadyExists, baseUrl));
-		}
-		
-		connect();
-		
 //		filewatcher = new CodewindFilewatcherdConnection(baseUrl.toString(), new ICodewindProjectTranslator() {
 //			@Override
 //			public Optional<String> getProjectId(IProject project) {
@@ -104,53 +101,62 @@ public class CodewindConnection {
 //			}
 //		});
 
-		Logger.log("Created " + this); //$NON-NLS-1$
 	}
 	
-	public void connect() throws IOException, URISyntaxException, JSONException {
-		connectionErrorMsg = null;
-		
-		if (!waitForReady()) {
-			Logger.logError("Timed out waiting for Codewind to go into ready state.");
-			isConnected = false;
-			connectionErrorMsg = getConnectionFailedMsg();
+	public void connect(IProgressMonitor monitor) throws IOException, URISyntaxException, JSONException {
+		if (isConnected) {
 			return;
 		}
 		
+		SubMonitor mon = SubMonitor.convert(monitor, 100);
+		if (!waitForReady(mon.split(20))) {
+			if (mon.isCanceled()) {
+				return;
+			}
+			Logger.logError("Timed out waiting for Codewind to go into ready state.");
+			onInitFail(Messages.Connection_ErrConnection_CodewindNotReady);
+		}
+		
+		mon.split(25);
 		env = new ConnectionEnv(getEnvData(this.baseUrl));
 		Logger.log("Codewind version is: " + env.getVersion());	// $NON-NLS-1$
 		if (!isSupportedVersion(env.getVersion())) {
 			Logger.logError("The detected version of Codewind is not supported: " + env.getVersion() + ", url: " + baseUrl);	// $NON-NLS-1$	// $NON-NLS-2$
-			this.connectionErrorMsg = NLS.bind(Messages.Connection_ErrConnection_OldVersion, env.getVersion(), InstallUtil.DEFAULT_INSTALL_VERSION);
+			onInitFail(NLS.bind(Messages.Connection_ErrConnection_OldVersion, env.getVersion(), InstallUtil.DEFAULT_INSTALL_VERSION));
+		}
+		if (mon.isCanceled()) {
 			return;
 		}
 
+		mon.split(5);
 		if (env.getWorkspacePath() == null) {
 			// Can't recover from this
 			// This should never happen since we have already determined it is a supported version of Codewind.
 			onInitFail(Messages.Connection_ErrConnection_WorkspaceErr);
 		}
-		
-		socket = new CodewindSocket(this);
-		if(!socket.blockUntilFirstConnection()) {
-			Logger.logError("Socket failed to connect: " + socket.socketUri);
-			close();
-			isConnected = false;
-			connectionErrorMsg = getConnectionFailedMsg();
+		if (mon.isCanceled()) {
 			return;
 		}
+		
+		socket = new CodewindSocket(this);
+		if(!socket.blockUntilFirstConnection(mon.split(30))) {
+			Logger.logError("Socket failed to connect: " + socket.socketUri);
+			close();
+			throw new CodewindConnectionException(socket.socketUri);
+		}
+		if (mon.isCanceled()) {
+			socket.close();
+			return;
+		}
+		
+		isConnected = true;
 
+		Logger.log("Connected to: " + this); //$NON-NLS-1$
+		
+		mon.split(20);
 		refreshApps(null);
 	}
-	
-	private String getConnectionFailedMsg() {
-		if (isLocal) {
-			return Messages.Connection_ErrConnection_ConnectionFailedLocal;
-		} else {
-			return Messages.Connection_ErrConnection_ConnectionFailed;
-		}
-	}
-	
+
 	public String getSocketNamespace() {
 		return env.getSocketNamespace();
 	}
@@ -379,14 +385,22 @@ public class CodewindConnection {
 		return null;
 	}
 	
-	public boolean waitForReady() throws IOException {
+	public boolean waitForReady(IProgressMonitor monitor) throws IOException {
+		SubMonitor mon = SubMonitor.convert(monitor, 100);
 		IOException exception = null;
 		for (int i = 0; i < 10; i++) {
 			try {
-				if (requestCodewindReady()) {
+				mon.split(10);
+				if (requestCodewindReady(500, 500)) {
 					return true;
 				}
-				Thread.sleep(1000);
+				if (mon.isCanceled()) {
+					return false;
+				}
+				Thread.sleep(500);
+				if (mon.isCanceled()) {
+					return false;
+				}
 			} catch (IOException e) {
 				exception = e;
 			} catch (InterruptedException e) {
@@ -399,10 +413,10 @@ public class CodewindConnection {
 		return false;
 	}
 	
-	public boolean requestCodewindReady() throws IOException {
+	public boolean requestCodewindReady(int connectTimeoutMS, int readTimeoutMS) throws IOException {
 		String endpoint = CoreConstants.APIPATH_READY;
 		URI uri = baseUrl.resolve(endpoint);
-		HttpResult result = HttpUtil.get(uri);
+		HttpResult result = HttpUtil.get(uri, connectTimeoutMS, readTimeoutMS);
 		checkResult(result, uri, true);
 		return "true".equals(result.response);
 	}
@@ -915,7 +929,7 @@ public class CodewindConnection {
 				// The socket namespace has changed so need to recreate the socket
 				socket.close();
 				socket = new CodewindSocket(this);
-				if(!socket.blockUntilFirstConnection()) {
+				if(!socket.blockUntilFirstConnection(new NullProgressMonitor())) {
 					// Still not connected
 					Logger.logError("Failed to create a new socket with updated URI: " + socket.socketUri);
 					// Clear the message so that it just shows the basic disconnected message
@@ -939,8 +953,8 @@ public class CodewindConnection {
 
 	@Override
 	public String toString() {
-		return String.format("%s @ baseUrl=%s workspacePath=%s numApps=%d", //$NON-NLS-1$
-				CodewindConnection.class.getSimpleName(), baseUrl, env.getWorkspacePath(), appMap.size());
+		return String.format("%s @ name=%s baseUrl=%s", //$NON-NLS-1$
+				CodewindConnection.class.getSimpleName(), name, baseUrl);
 	}
 
 	// Note that toPrefsString and fromPrefsString are used to save and load connections from the preferences store

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnectionManager.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnectionManager.java
@@ -22,6 +22,7 @@ import org.eclipse.codewind.core.internal.CodewindApplication;
 import org.eclipse.codewind.core.internal.CodewindObjectFactory;
 import org.eclipse.codewind.core.internal.CoreUtil;
 import org.eclipse.codewind.core.internal.Logger;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -197,6 +198,7 @@ public class CodewindConnectionManager {
 					String uriStr = obj.getString(URI_KEY);
 					URI uri = new URI(uriStr);
 					CodewindConnection connection = CodewindObjectFactory.createCodewindConnection(name, uri, false);
+					connection.connect(new NullProgressMonitor());
 					CodewindConnectionManager.add(connection);
 				} catch (CodewindConnectionException e) {
 					Logger.logError("Fatal error trying to create connection for url: " + e.connectionUrl, e);

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindSocket.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindSocket.java
@@ -28,6 +28,8 @@ import org.eclipse.codewind.core.internal.constants.CoreConstants;
 import org.eclipse.codewind.core.internal.constants.ProjectType;
 import org.eclipse.codewind.core.internal.constants.StartMode;
 import org.eclipse.codewind.core.internal.messages.Messages;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.osgi.util.NLS;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -556,11 +558,13 @@ public class CodewindSocket {
 		return false;
 	}
 
-	boolean blockUntilFirstConnection() {
+	boolean blockUntilFirstConnection(IProgressMonitor monitor) {
+		SubMonitor mon = SubMonitor.convert(monitor, 2500);
 		final int delay = 100;
 		final int timeout = 2500;
 		int waited = 0;
 		while(!hasConnected && waited < timeout) {
+			mon.split(100);
 			try {
 				Thread.sleep(delay);
 				waited += delay;
@@ -571,6 +575,9 @@ public class CodewindSocket {
 			}
 			catch(InterruptedException e) {
 				Logger.logError(e);
+			}
+			if (mon.isCanceled()) {
+				return false;
 			}
 		}
 		Logger.log("CodewindSocket initialized in time ? " + hasConnected); //$NON-NLS-1$

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
@@ -28,8 +28,7 @@ public class Messages extends NLS {
 	public static String Connection_ErrContactingServerDialogTitle;
 	public static String Connection_ErrGettingProjectListTitle;
 	public static String Connection_ErrConnection_UpdateCacheException;
-	public static String Connection_ErrConnection_ConnectionFailedLocal;
-	public static String Connection_ErrConnection_ConnectionFailed;
+	public static String Connection_ErrConnection_CodewindNotReady;
 
 	public static String ConnectionException_ConnectingToMCFailed;
 

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
@@ -21,8 +21,7 @@ Connection_ErrContactingServerDialogMsg=Failed to contact the Codewind server at
 Connection_ErrContactingServerDialogTitle=Error contacting Codewind server
 Connection_ErrGettingProjectListTitle=Error getting list of projects
 Connection_ErrConnection_UpdateCacheException=An error occurred while initializing the Codewind connection. Check the workspace logs.
-Connection_ErrConnection_ConnectionFailedLocal=Failed to connect to Codewind. Use the context menu to try stopping and re-starting Codewind.
-Connection_ErrConnection_ConnectionFailed=Failed to connect to Codewind. Check that it is running and use the context menu to try connecting again.
+Connection_ErrConnection_CodewindNotReady=Codewind failed to go into the ready state. Try stopping and re-starting Codewind.
 
 ConnectionException_ConnectingToMCFailed=Connecting to Codewind at {0} failed.
 

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/IDEUtil.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/IDEUtil.java
@@ -11,8 +11,14 @@
 
 package org.eclipse.codewind.ui.internal;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.messages.Messages;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.MultiStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
@@ -71,6 +77,16 @@ public class IDEUtil {
     public static void normalizeBackground(Control control, Control parent) {
     	control.setBackground(parent.getBackground());
     	control.setForeground(parent.getForeground());
+    }
+    
+    public static MultiStatus getMultiStatus(String msg, Exception e) {
+    	List<Status> statusList = new ArrayList<Status>();
+    	StackTraceElement[] elems = e.getStackTrace();
+    	for (StackTraceElement elem : elems) {
+    		statusList.add(new Status(IStatus.ERROR, CodewindUIPlugin.PLUGIN_ID, elem.toString()));
+    	}
+    	return new MultiStatus(CodewindUIPlugin.PLUGIN_ID, IStatus.ERROR,
+    			statusList.toArray(new Status[statusList.size()]), e.toString(), e);
     }
 
 }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -34,14 +34,14 @@ public class Messages extends NLS {
 
 	public static String NewConnectionPage_ConnectSucceeded;
 	public static String NewConnectionPage_ErrAConnectionAlreadyExists;
-	public static String NewConnectionPage_ErrCouldNotConnectToMC;
+	public static String NewConnectionPage_ErrCouldNotConnect;
 	public static String NewConnectionPage_HostnameLabel;
 	public static String NewConnectionPage_NotValidPortNum;
 	public static String NewConnectionPage_OnlyLocalhostSupported;
 	public static String NewConnectionPage_PortLabel;
 	public static String NewConnectionPage_ShellTitle;
 	public static String NewConnectionPage_TestConnectionBtn;
-	public static String NewConnectionPage_TestToProceed;
+	public static String NewConnectionPage_TestConnectionJobLabel;
 	public static String NewConnectionPage_WizardDescription;
 	public static String NewConnectionPage_WizardTitle;
 	public static String NewConnectionWizard_ShellTitle;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -27,14 +27,14 @@ PrefsParentPage_ErrInvalidTimeout=The timeout value "{0}" is not valid. Enter an
 
 NewConnectionPage_ConnectSucceeded=Connecting to {0} succeeded.
 NewConnectionPage_ErrAConnectionAlreadyExists=You already have an existing Codewind connection at {0}.\nOnly one Codewind connection is permitted.
-NewConnectionPage_ErrCouldNotConnectToMC=Eclipse could not connect to Codewind at {0}.
+NewConnectionPage_ErrCouldNotConnect=Eclipse could not connect to Codewind at {0}.
 NewConnectionPage_HostnameLabel=&Hostname:
 NewConnectionPage_NotValidPortNum={0} is not a valid port number. Enter an integer for the port number.
 NewConnectionPage_OnlyLocalhostSupported=Only localhost is supported.
 NewConnectionPage_PortLabel=&Port:
 NewConnectionPage_ShellTitle=New Codewind connection
 NewConnectionPage_TestConnectionBtn=&Test connection
-NewConnectionPage_TestToProceed=Test your new connection to proceed.
+NewConnectionPage_TestConnectionJobLabel=Connecting to Codewind at {0}
 NewConnectionPage_WizardDescription=Create a connection to a Codewind instance.
 NewConnectionPage_WizardTitle=Create a Codewind connection
 NewConnectionWizard_ShellTitle=New Codewind connection

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindConnectionWizard.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindConnectionWizard.java
@@ -26,15 +26,16 @@ import org.eclipse.ui.IWorkbench;
 public class NewCodewindConnectionWizard extends Wizard implements INewWizard {
 
 	private NewCodewindConnectionPage newConnectionPage;
+	
+	public NewCodewindConnectionWizard() {
+		setDefaultPageImageDescriptor(CodewindUIPlugin.getImageDescriptor(CodewindUIPlugin.CODEWIND_BANNER));
+		setHelpAvailable(false);
+		setNeedsProgressMonitor(true);		
+	}
 
 	@Override
 	public void init(IWorkbench workbench, IStructuredSelection selection) {
-
-		setDefaultPageImageDescriptor(CodewindUIPlugin.getImageDescriptor(CodewindUIPlugin.CODEWIND_BANNER));
-
-		// TODO help
-		setHelpAvailable(false);
-		setNeedsProgressMonitor(true);
+		// Empty
 	}
 
 	@Override


### PR DESCRIPTION
- Common up code in HttpUtil and make sure there is a connect timeout for everything
- Add a progress bar with cancel button to the new connection page when the user clicks Test Connection
- Split out connect code from constructor so can call separately
- Throw exceptions back to the caller so the original exception can be shown to the user
- In order to show the exception with the stack trace, return a multistatus where each line of the stack trace is added as a child status