### PR TITLE
CW Issue #469: Improve the error message if delete fails because of Maven jobs

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
@@ -339,7 +339,7 @@ public class CodewindEclipseApplication extends CodewindApplication {
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
 					IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(name);
-					if (project != null && project.exists() && project.getLocation().toFile().equals(fullLocalPath.toFile())) {
+					if (project != null && project.exists() && project.getLocation().equals(fullLocalPath)) {
 						project.delete(true, true, monitor);
 					} else if (fullLocalPath.toFile().exists()) {
 						FileUtil.deleteDirectory(fullLocalPath.toOSString(), true);

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
@@ -68,7 +68,7 @@ RemovingCodewindJobLabel=Removing Codewind docker images
 CreateProjectTaskLabel=Creating project: {0}
 ValidateProjectTaskLabel=Validating project: {0}
 DeleteProjectJobLabel=Deleting project contents: {0}
-DeleteProjectError=An error occurred while trying to delete the contents of the {0} project.
+DeleteProjectError=There may be running operations that are holding on to resources. Wait for operations to complete and then try deleting {0} from the Project Explorer view.
 
 ProjectSettingsUpdateErrorTitle=Project settings update error
 


### PR DESCRIPTION
Improve the error message if project content delete fails because of Maven jobs.  Also removed an unnecessary conversion to File.