### PR TITLE
Fix minor UI issues with the add existing project wizard

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectSelectionPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectSelectionPage.java
@@ -205,8 +205,6 @@ public class ProjectSelectionPage extends WizardPage {
 				String selectedDirectory = dialog.open();
 				if (selectedDirectory != null && !selectedDirectory.trim().isEmpty()) {
 					pathText.setText(selectedDirectory.trim());
-				} else {
-					pathText.setText(""); //$NON-NLS-1$
 				}
 				validate();
 			}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectValidationPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectValidationPage.java
@@ -79,6 +79,7 @@ public class ProjectValidationPage extends WizardPage {
 		
 		setProjectPath(projectPath, false);
 
+		validateMsg.setFocus();
 		setControl(composite);
 	}
 


### PR DESCRIPTION
- Don't clear out the old text if the user cancels the directory browse dialog
- Set the focus on the validation message