### PR TITLE
CW Issue #649: Hide CW settings button if the file does not exist

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/IDEUtil.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/IDEUtil.java
@@ -17,6 +17,7 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
@@ -72,5 +73,10 @@ public class IDEUtil {
     	control.setBackground(parent.getBackground());
     	control.setForeground(parent.getForeground());
     }
+    
+	public static void setControlVisibility(Control control, boolean visible) {
+		control.setVisible(visible);
+		((GridData)control.getLayoutData()).exclude = !visible;
+	}
 
 }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
@@ -489,10 +489,28 @@ public class ApplicationOverviewEditorPart extends EditorPart {
 				debugPort = Messages.AppOverviewEditorDebugNotSupported;
 			}
 			debugPortEntry.setValue(debugPort, true);
+			boolean hasSettingsFile = hasSettingsFile(app);
+			IDEUtil.setControlVisibility(editButton, hasSettingsFile);
+			IDEUtil.setControlVisibility(infoButton, hasSettingsFile);
 		}
 		
 		public void enableWidgets(boolean enable) {
 			// Nothing to do
+		}
+		
+		private boolean hasSettingsFile(CodewindApplication app) {
+			IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(app.name);
+			if (project != null && project.isAccessible()) {
+				IFile file = project.getFile(SETTINGS_FILE);
+				if (file != null && file.exists()) {
+					return true;
+				}
+			}
+			IPath path = app.fullLocalPath.append(SETTINGS_FILE);
+			if (path.toFile().exists()) {
+				return true;
+			}
+			return false;
 		}
 	}
 	
@@ -660,16 +678,12 @@ public class ApplicationOverviewEditorPart extends EditorPart {
 			this.linkUrl = linkUrl;
 			if (linkUrl != null && !linkUrl.isEmpty()) {
 				link.setText(linkUrl);
-				link.setVisible(true);
-				((GridData)link.getLayoutData()).exclude = false;
-				text.setVisible(false);
-				((GridData)text.getLayoutData()).exclude = true;
+				IDEUtil.setControlVisibility(link, true);
+				IDEUtil.setControlVisibility(text, false);
 				link.setEnabled(enabled);
 			} else {
-				link.setVisible(false);
-				((GridData)link.getLayoutData()).exclude = true;
-				text.setVisible(true);
-				((GridData)text.getLayoutData()).exclude = false;
+				IDEUtil.setControlVisibility(link, false);
+				IDEUtil.setControlVisibility(text, true);
 			}
 		}
 	}


### PR DESCRIPTION
Eclipse IDE PR for https://github.com/eclipse/codewind/issues/649

Hide the CW settings edit and info buttons if the file does not exist.