### PR TITLE
Issue #299: Add a learn more link to the manage template sources dialog

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -346,6 +346,7 @@ public class Messages extends NLS {
 	public static String RepoMgmtDialogMessage;
 	
 	public static String RepoMgmtDescription;
+	public static String RepoMgmtLearnMoreLink;
 	public static String RepoMgmtTableLabel;
 	public static String RepoMgmtAddButton;
 	public static String RepoMgmtRemoveButton;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -339,6 +339,7 @@ RepoMgmtDialogTitle=Manage Template Sources
 RepoMgmtDialogMessage=Add, remove, enable and disable template sources
 
 RepoMgmtDescription=Enable or disable template sources using the check boxes. Use the buttons to add and remove template sources. Default template sources cannot be removed.
+RepoMgmtLearnMoreLink=Learn more...
 RepoMgmtTableLabel=Template &sources
 RepoMgmtAddButton=&Add...
 RepoMgmtRemoveButton=&Remove

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/RepositoryManagementComposite.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/RepositoryManagementComposite.java
@@ -61,6 +61,8 @@ import org.eclipse.ui.browser.IWorkbenchBrowserSupport;
 
 public class RepositoryManagementComposite extends Composite {
 	
+	private static final String DOC_URL = "https://www.eclipse.org/codewind/mdteclipseusingadifferenttemplate.html";
+	
 	private final CodewindConnection connection;
 	private final List<RepositoryInfo> repoList;
 	private List<RepoEntry> repoEntries;
@@ -94,7 +96,25 @@ public class RepositoryManagementComposite extends Composite {
 		description.setText("");
 		description.setBackground(this.getBackground());
 		description.setForeground(this.getForeground());
-		description.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false, 2, 1));
+		description.setLayoutData(new GridData(GridData.FILL, GridData.END, true, false, 1, 1));
+		
+		Link learnMoreLink = new Link(this, SWT.NONE);
+		learnMoreLink.setText("<a>" + Messages.RepoMgmtLearnMoreLink + "</a>");
+		learnMoreLink.setLayoutData(new GridData(GridData.END, GridData.END, false, false, 1, 1));
+		
+		learnMoreLink.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent event) {
+				try {
+					IWorkbenchBrowserSupport browserSupport = PlatformUI.getWorkbench().getBrowserSupport();
+					IWebBrowser browser = browserSupport.getExternalBrowser();
+					URL url = new URL(DOC_URL);
+					browser.openURL(url);
+				} catch (Exception e) {
+					Logger.logError("An error occurred trying to open an external browser at: " + DOC_URL, e); //$NON-NLS-1$
+				}
+			}
+		});
 		
 		new Label(this, SWT.NONE).setLayoutData(new GridData(GridData.FILL, GridData.FILL, false, false, 2, 1));
 		


### PR DESCRIPTION
Fixes #299 

Add a learn more link to the manage template source dialog.  It opens an external browser since an internal browser would be hidden by the dialog itself.