### PR TITLE
Use CWCTL CLI 'project sync' command to build and sync.

### DIFF
--- a/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/CLIState.java
+++ b/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/CLIState.java
@@ -1,0 +1,321 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.codewind.filewatchers.core.internal;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.codewind.filewatchers.core.FWLogger;
+import org.eclipse.codewind.filewatchers.core.FilewatcherUtils;
+
+/* The purpose of this class is to call the cwctl project sync command, in order to allow the
+ * Codewind CLI to detect and communicate file changes to the server.
+ *
+ * This class will ensure that only one instance of the cwctl project sync command is running
+ * at a time, per project.
+ *
+ * For automated testing, if the `MOCK_CWCTL_INSTALLER_PATH` environment variable is specified, a mock cwctl command
+ * written in Java (as a runnable JAR) can be used to test this class.
+ */
+public class CLIState {
+
+	private final String projectId;
+
+	/*
+	 * Absolute time, in unix epoch msecs, at which the last cwctl command was
+	 * initiated. Note this is different from the actual value we provide to cwctl.
+	 */
+	private long timestamp_synch_lock = 0;
+
+	private final String installerPath;
+
+	private final String projectPath;
+
+	/** For automated testing only */
+	private final String mockInstallerPath;
+
+	private final FWLogger log = FWLogger.getInstance();
+
+	private boolean processActive_synch_lock = false;
+	private boolean requestWaiting_synch_lock = false;
+
+	private final Object lock = new Object();
+
+	public CLIState(String projectId, String installerPath, String projectPath) {
+
+		if (installerPath == null) {
+			throw new RuntimeException("Installer path is null: " + installerPath);
+		}
+
+		this.projectId = projectId;
+		this.installerPath = installerPath;
+		this.projectPath = projectPath;
+
+		this.mockInstallerPath = System.getenv("MOCK_CWCTL_INSTALLER_PATH");
+	}
+
+	public void onFileChangeEvent() {
+
+		if (this.projectPath == null || this.projectPath.trim().isEmpty()) {
+			log.logSevere("Project path passed to CLIState is empty, so ignoring file change event.");
+			return;
+		}
+
+		boolean callCLI = false;
+
+		synchronized (lock) {
+			// This, along with callCLI(), ensures that only one instance of `project sync`
+			// is running at a time.
+			if (processActive_synch_lock) {
+				requestWaiting_synch_lock = true;
+			} else {
+				processActive_synch_lock = true;
+				requestWaiting_synch_lock = false;
+				callCLI = true;
+			}
+		}
+
+		// Call CLI outside the lock
+		if (callCLI) {
+			FilewatcherUtils.newThread(() -> {
+				callCLI();
+			});
+		}
+
+	}
+
+	private void callCLI() {
+
+		// Sanity check the processActive field
+		synchronized (lock) {
+			if (!processActive_synch_lock) {
+				log.logSevere(CLIState.class.getSimpleName()
+						+ ".callCLI() was called while the processActive value was false. This should never happen.");
+			}
+		}
+
+		final boolean DEBUG_FAKE_CMD_OUTPUT = false; // Enable this for debugging purposes.
+
+		// This try block works in tandem with onFileChangeEvent() to ensure that only
+		// one instance of the
+		// 'project sync' command is running at a time.
+		try {
+
+			RunProjectReturn result;
+
+			if (DEBUG_FAKE_CMD_OUTPUT) {
+				synchronized (lock) {
+					log.logInfo("Faking a call to CLI with params " + timestamp_synch_lock + " " + projectId);
+					result = new RunProjectReturn(0, "", System.currentTimeMillis());
+				}
+
+			} else {
+				// Call CLI and wait for result
+				result = runProjectCommand();
+			}
+
+			if (result != null) {
+				if (result.errorCode != 0) {
+					log.logSevere("Non-zero error code from installer: "
+							+ (result != null && result.output != null ? result.output : ""));
+				} else {
+					synchronized (lock) {
+						// Success, so update the tiemstamp to the process start time.
+						this.timestamp_synch_lock = result.spawnTime;
+						log.logInfo("Updating timestamp to latest: " + timestamp_synch_lock);
+
+					}
+				}
+			}
+
+		} catch (Throwable e) {
+			// Log, handle, then bury the exception
+			log.logSevere("Unexpected exception from CLI", e, projectId);
+		}
+
+		boolean requestWaiting = false;
+		synchronized (lock) {
+			this.processActive_synch_lock = false;
+
+			// If another file change list occurred during the last invocation, then start
+			// another one.
+			requestWaiting = this.requestWaiting_synch_lock;
+
+		}
+
+		if (requestWaiting) {
+			onFileChangeEvent();
+		}
+
+	}
+
+	private RunProjectReturn runProjectCommand() throws IOException, InterruptedException {
+
+		String currInstallerPath = this.installerPath;
+
+		List<String> args = new ArrayList<>();
+
+		long adjustedTimestamp;
+		synchronized (lock) {
+			// Convert the absolute timestamp to # of msecs since start of last run.
+			adjustedTimestamp = System.currentTimeMillis() - timestamp_synch_lock;
+
+		}
+
+		if (this.mockInstallerPath == null || this.mockInstallerPath.trim().isEmpty()) {
+			args.add(q(installerPath));
+
+			// Example:
+			// cwctl project sync -p
+			// /Users/tobes/workspaces/git/eclipse/codewind/codewind-workspace/lib5 \
+			// -i b1a78500-eaa5-11e9-b0c1-97c28a7e77c7 -t 12345
+			args.addAll(Arrays.asList(new String[] { "project", "sync", "-p", q(projectPath), "-i", projectId, "-t",
+					"" + adjustedTimestamp }));
+		} else {
+
+			args.add("java");
+
+			args.addAll(Arrays.asList(new String[] { "-jar", q(this.mockInstallerPath), "-p", q(this.projectPath), "-i",
+					this.projectId, "-t", "" + adjustedTimestamp }));
+
+			currInstallerPath = mockInstallerPath;
+		}
+
+		String debugStr = args.stream().map(e -> "[" + e + "] ").reduce((a, b) -> a + b).get();
+
+		log.logInfo("Calling cwctl project sync with: [" + this.projectId + "] { " + debugStr + "}");
+
+		// Start process and wait for complete on this thread.
+
+		String installerPwd = new File(currInstallerPath).getParent();
+
+		long spawnTime = System.currentTimeMillis();
+		ProcessBuilder pb = new ProcessBuilder(args);
+		pb.directory(new File(installerPwd));
+		Process p = pb.start();
+
+		ReadThread inputStreamThread = new ReadThread(p.getInputStream(), null);
+		inputStreamThread.start();
+
+		ReadThread errorStreamThread = new ReadThread(p.getErrorStream(), null);
+		errorStreamThread.start();
+
+		// Wait for complete.
+
+		int result = p.waitFor();
+
+		log.logInfo("Cwctl call completed, elapsed time of cwctl call: " + (System.currentTimeMillis() - spawnTime));
+
+		String stdout = inputStreamThread.getOutput();
+		String stderr = errorStreamThread.getOutput();
+
+		// Log result.
+
+		if (result != 0) {
+			log.logError("Error running 'project sync' installer command");
+			log.logError("Stdout: " + stdout);
+			log.logError("Stderr:" + stderr);
+
+			return new RunProjectReturn(result, stdout + stderr, spawnTime);
+
+		} else {
+			log.logInfo("Successfully ran installer command: " + debugStr);
+			log.logInfo("Output:" + stdout); // TODO: Convert to DEBUG once everything matures.
+
+			return new RunProjectReturn(result, stdout, spawnTime);
+
+		}
+
+	}
+
+	/** Wrap string in quotes, if not null */
+	private static String q(String str) {
+		if (str == null) {
+			// Preserve null semantics
+			return null;
+		}
+		return "\"" + str + "\"";
+	}
+
+	/** Return value of runProjectCommand(). */
+	private static class RunProjectReturn {
+		int errorCode;
+		String output;
+		long spawnTime;
+
+		public RunProjectReturn(int errorCode, String output, long spawnTime) {
+			this.errorCode = errorCode;
+			this.output = output;
+			this.spawnTime = spawnTime;
+		}
+
+	}
+
+	/**
+	 * Read from an InputStream, append the result to a StringBuilder. Thread safe.
+	 */
+	private class ReadThread extends Thread {
+
+		final InputStream is;
+		final PrintStream ps;
+
+		private final StringBuilder received_synch = new StringBuilder();
+
+		@SuppressWarnings("unused")
+		private boolean isFinished = false;
+
+		public ReadThread(InputStream is, PrintStream ps) {
+			this.is = is;
+			this.ps = ps;
+			setDaemon(true);
+		}
+
+		@Override
+		public void run() {
+
+			BufferedReader br = new BufferedReader(new InputStreamReader(is));
+
+			String str;
+			try {
+				while (null != (str = br.readLine())) {
+
+					if (ps != null) {
+						ps.append(str + "\n");
+					}
+
+					synchronized (received_synch) {
+						received_synch.append(str + "\n");
+					}
+
+				}
+				isFinished = true;
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+
+		}
+
+		public String getOutput() {
+			synchronized (received_synch) {
+				return received_synch.toString();
+
+			}
+		}
+	}
+}

--- a/dev/org.eclipse.codewind.filewatchers.eclipse/src/org/eclipse/codewind/filewatchers/eclipse/CodewindFilewatcherdConnection.java
+++ b/dev/org.eclipse.codewind.filewatchers.eclipse/src/org/eclipse/codewind/filewatchers/eclipse/CodewindFilewatcherdConnection.java
@@ -50,7 +50,16 @@ public class CodewindFilewatcherdConnection {
 
 	private final String clientUuid;
 
-	public CodewindFilewatcherdConnection(String baseHttpUrl, ICodewindProjectTranslator translator) {
+	public CodewindFilewatcherdConnection(String baseHttpUrl, File pathToCwctl, ICodewindProjectTranslator translator) {
+
+		if(pathToCwctl == null) {
+			throw new RuntimeException("A valid path to the Codewind CLI is required: "+pathToCwctl);
+		}
+		
+		if (!pathToCwctl.exists() || !pathToCwctl.canExecute()) {
+			throw new RuntimeException(
+					this.getClass().getSimpleName() + " was passed an invalid installer path: " + pathToCwctl.getPath());
+		}
 
 		this.clientUuid = UUID.randomUUID().toString();
 
@@ -77,7 +86,8 @@ public class CodewindFilewatcherdConnection {
 		// inside the workspace, and the Java-NIO-JVM-based watch service for folders
 		// outside the workspace (eg the standalone Codewind settings directory).
 		this.platformWatchService = new EclipseResourceWatchService();
-		this.fileWatcher = new Filewatcher(url, clientUuid, platformWatchService, new JavaNioWatchService());
+		this.fileWatcher = new Filewatcher(url, clientUuid, platformWatchService, new JavaNioWatchService(),
+				pathToCwctl.getPath());
 
 		this.baseHttpUrl = url;
 

--- a/dev/org.eclipse.codewind.filewatchers.standalonenio/src/org/eclipse/codewind/filewatchers/Main.java
+++ b/dev/org.eclipse.codewind.filewatchers.standalonenio/src/org/eclipse/codewind/filewatchers/Main.java
@@ -51,7 +51,9 @@ public class Main {
 
 		IPlatformWatchService platformWatchService = new JavaNioWatchService();
 
-		Filewatcher fw = new Filewatcher(url, UUID.randomUUID().toString(), platformWatchService, null);
+		String pathToCli = System.getenv("MOCK_CWCTL_INSTALLER_PATH");
+
+		Filewatcher fw = new Filewatcher(url, UUID.randomUUID().toString(), platformWatchService, null, pathToCli);
 
 		while (true) {
 			FilewatcherUtils.sleepIgnoreInterrupt(1000);


### PR DESCRIPTION
In order to support the new Codewind architecture, the Java-based Filewatcherd will now call the cwctl CLI project sync command, instead of POSTing to Turbine.