### PR TITLE
Fix broken, unnecessary path wrapping in CLI process launcher

### DIFF
--- a/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/CLIState.java
+++ b/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/CLIState.java
@@ -179,19 +179,19 @@ public class CLIState {
 		}
 
 		if (this.mockInstallerPath == null || this.mockInstallerPath.trim().isEmpty()) {
-			args.add(q(installerPath));
+			args.add(installerPath);
 
 			// Example:
 			// cwctl project sync -p
 			// /Users/tobes/workspaces/git/eclipse/codewind/codewind-workspace/lib5 \
 			// -i b1a78500-eaa5-11e9-b0c1-97c28a7e77c7 -t 12345
-			args.addAll(Arrays.asList(new String[] { "project", "sync", "-p", q(projectPath), "-i", projectId, "-t",
+			args.addAll(Arrays.asList(new String[] { "project", "sync", "-p", projectPath, "-i", projectId, "-t",
 					"" + adjustedTimestamp }));
 		} else {
 
 			args.add("java");
 
-			args.addAll(Arrays.asList(new String[] { "-jar", q(this.mockInstallerPath), "-p", q(this.projectPath), "-i",
+			args.addAll(Arrays.asList(new String[] { "-jar", this.mockInstallerPath, "-p", this.projectPath, "-i",
 					this.projectId, "-t", "" + adjustedTimestamp }));
 
 			currInstallerPath = mockInstallerPath;
@@ -242,15 +242,6 @@ public class CLIState {
 
 		}
 
-	}
-
-	/** Wrap string in quotes, if not null */
-	private static String q(String str) {
-		if (str == null) {
-			// Preserve null semantics
-			return null;
-		}
-		return "\"" + str + "\"";
 	}
 
 	/** Return value of runProjectCommand(). */


### PR DESCRIPTION
Discovered during automated testing on the other filewatchers: not only is wrapping the path in double quotation marks unnecessary, it is actively harmful on non-Windows platforms.

I've verified that the new version of the code continues to properly handle paths with spaces in them.