### PR TITLE
CW Issue #723: Remove unnecessary second label for web browser combo

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -251,7 +251,7 @@ NodeJSDebugURLError=Failed to get the debug URL for the {0} application.
 
 BrowserSelectionTitle=Launch the Node.js Debugger
 BrowserSelectionDescription=Select a Chromium based web browser for launching the Node.js debugger.
-BrowserSelectionLabel=Select a Chromium based web browser for launching the Node.js debugger:
+BrowserSelectionLabel=Select a Chromium based &web browser for launching the Node.js debugger:
 BrowserSelectionAlwaysUseMsg=Always use selected Chromium based web browser for Node.js debugging
 BrowserSelectionManageButtonText=Manage...
 BrowserSelectionListLabel=&Web browser:

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/CodewindPrefsParentPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/CodewindPrefsParentPage.java
@@ -18,7 +18,6 @@ import org.eclipse.codewind.core.CodewindCorePlugin;
 import org.eclipse.codewind.core.internal.InstallUtil;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
-import org.eclipse.codewind.ui.internal.IDEUtil;
 import org.eclipse.codewind.ui.internal.actions.CodewindInstall;
 import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -189,24 +188,19 @@ public class CodewindPrefsParentPage extends PreferencePage implements IWorkbenc
 			}
 		});
 		 	    
-	    Text browserSelectionLabel = new Text(debugGroup, SWT.READ_ONLY | SWT.SINGLE);
-	    browserSelectionLabel.setText(Messages.BrowserSelectionLabel);
-	    browserSelectionLabel.setLayoutData(new GridData(GridData.BEGINNING, GridData.FILL, false, false, 3, 1));
-	    IDEUtil.normalizeBackground(browserSelectionLabel, debugGroup);
-	    
 	    final Composite selectWebBrowserComposite = new Composite(debugGroup, SWT.NONE);
 	    layout = new GridLayout();
 		layout.horizontalSpacing = convertHorizontalDLUsToPixels(4);
 		layout.verticalSpacing = convertVerticalDLUsToPixels(3);
-		layout.marginWidth = 20;
+		layout.marginWidth = 3;
 		layout.marginHeight = 2;
-	    layout.numColumns = 3;
+	    layout.numColumns = 2;
 	    selectWebBrowserComposite.setLayout(layout);
 	    selectWebBrowserComposite.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false, 2, 1));
 	    
-        Label selectWebBrowserLabel = new Label(selectWebBrowserComposite, SWT.NONE );
-        selectWebBrowserLabel.setText(Messages.BrowserSelectionListLabel);	
-        selectWebBrowserLabel.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, false, false, 1, 1));
+	    Label browserSelectionLabel = new Label(selectWebBrowserComposite, SWT.NONE);
+	    browserSelectionLabel.setText(Messages.BrowserSelectionLabel);
+	    browserSelectionLabel.setLayoutData(new GridData(GridData.BEGINNING, GridData.FILL, false, false, 2, 1));
         
         webBrowserCombo = new Combo(selectWebBrowserComposite, SWT.BORDER | SWT.READ_ONLY);
         


### PR DESCRIPTION
The combo box for selecting a web browser for Node.js debugging does not need 2 labels. The first, longer label will still be read by the screen reader as long as the next widget is the combo box (even if on a separate line) so remove the shorter label.