### PR TITLE
Issue #394: Update feature and plugin versions for 0.6.0

### DIFF
--- a/dev/ant_build/build-cw.xml
+++ b/dev/ant_build/build-cw.xml
@@ -10,7 +10,7 @@
 -->
 
 <project name="cw_build" default="generateOpenCWUpdateSite">
-    <property name="level_tag" value="0.5.0"/>
+    <property name="level_tag" value="0.6.0"/>
     <property name="delegate.build.dir" location="${basedir}/../" />
     <property name="disable.run.executeMetatypeValidation" value="true"/>
     <property name="disable.run.unzipIfixReleaseZip" value="true"/>

--- a/dev/org.eclipse.codewind.base/feature.xml
+++ b/dev/org.eclipse.codewind.base/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.codewind.base"
       label="%featureName"
-      version="1.3.0.qualifier"
+      version="1.4.0.qualifier"
       provider-name="%providerName">
 
    <description>
@@ -40,21 +40,21 @@
          install-size="0"
          version="0.0.0"
          unpack="false"/>
-         
+
    <plugin
          id="org.eclipse.codewind.filewatchers.core"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
-         
+
    <plugin
          id="org.eclipse.codewind.filewatchers.eclipse"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
-         
+
    <plugin
          id="org.eclipse.codewind.filewatchers.standalonenio"
          download-size="0"

--- a/dev/org.eclipse.codewind.core/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Codewind Core Plug-in
 Bundle-SymbolicName: org.eclipse.codewind.core;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.4.0.qualifier
 Bundle-Activator: org.eclipse.codewind.core.CodewindCorePlugin
 Bundle-Vendor: Eclipse.org
 Bundle-Localization: plugin

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/InstallUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/InstallUtil.java
@@ -49,7 +49,7 @@ public class InstallUtil {
 	private static final String REMOVE_CMD = "remove";
 	private static final String UPGRADE_CMD = "upgrade";
 	
-	public static final String DEFAULT_INSTALL_VERSION = "0.5.0";
+	public static final String DEFAULT_INSTALL_VERSION = "0.6.0";
 	
 	private static final String TAG_OPTION = "-t";
 	private static final String INSTALL_VERSION_VAR = "INSTALL_VERSION";

--- a/dev/org.eclipse.codewind.filewatchers.core/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.filewatchers.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Codewind Filewatcher Core Plug-in
 Bundle-SymbolicName: org.eclipse.codewind.filewatchers.core;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-ClassPath: .,
  lib/grizzly-framework-2.4.4.jar,

--- a/dev/org.eclipse.codewind.filewatchers.eclipse/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.filewatchers.eclipse/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Codewind Filewatcher Eclipse Plug-in
 Bundle-SymbolicName: org.eclipse.codewind.filewatchers.eclipse;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.codewind.filewatchers.eclipse
 Import-Package: org.eclipse.codewind.filewatchers,

--- a/dev/org.eclipse.codewind.filewatchers.standalonenio/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.filewatchers.standalonenio/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Codewind Filewatcher Standalonenio Plug-in
 Bundle-SymbolicName: org.eclipse.codewind.filewatchers.standalonenio;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.codewind.filewatchers
 Import-Package: org.eclipse.codewind.filewatchers.core

--- a/dev/org.eclipse.codewind.test/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Codewind Test Plug-in
 Bundle-SymbolicName: org.eclipse.codewind.test;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.3.0.qualifier
 Bundle-Activator: org.eclipse.codewind.test.CodewindTestPlugin
 Bundle-Vendor: Eclipse.org
 Require-Bundle: org.eclipse.core.runtime

--- a/dev/org.eclipse.codewind.ui/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Codewind UI Plug-in
 Bundle-SymbolicName: org.eclipse.codewind.ui;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.4.0.qualifier
 Bundle-Activator: org.eclipse.codewind.ui.CodewindUIPlugin
 Bundle-Vendor: Eclipse.org
 Bundle-Localization: plugin

--- a/dev/org.eclipse.codewind/feature.xml
+++ b/dev/org.eclipse.codewind/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.codewind"
       label="%featureName"
-      version="0.5.0.qualifier"
+      version="0.6.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.codewind.core">
 


### PR DESCRIPTION
Fixes #394

Update the plugin and feature versions for 0.6.0. Also update the default Codewind tag.