### PR TITLE
Add a getDependencies gradle task

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ build/dev/ant_build/artifacts/codewind-[Version].vYYYYMMDD_hhmm.zip
  ```
  git clone https://github.com/eclipse/codewind-eclipse
  ```
+- From the `codewind-eclipse/dev` directory run `gradlew getDependencies` to download the dependency jars.
 - The extension bundles dependency executables. These are gitignored, but should be kept up-to-date on your local system with the same versions used in the `Jenkinsfile` `parameters` section. Run `dev/org.eclipse.codewind.core/binaries/meta-pull.sh` to pull down the required scripts from the codewind-vscode repository, then run `dev/org.eclipse.codewind.core/binaries/pull.sh` to download the dependencies. Also see `dev/org.eclipse.codewind.core/binaries/README.txt`, and the downloaded `dev/org.eclipse.codewind.core/binaries/README-pull.txt`.
 - Open the **Git Repositories** view in Eclipse and click on the **Add an existing local Git Repository to this view** toolbar button.
 - Fill in the location of your repository clone and finish the wizard.

--- a/dev/build.gradle
+++ b/dev/build.gradle
@@ -52,4 +52,10 @@ task buildAll(type: GradleBuild) {
     buildFile = 'buildAll.gradle'
 }
 
+task getDependencies(type: GradleBuild) {
+    buildFile = 'buildAll.gradle'
+    tasks = ['getCoreDependencies', 'getFWCoreDependencies']
+}
+
 buildAll.dependsOn downloadUpdateSiteJar
+getDependencies.dependsOn downloadUpdateSiteJar


### PR DESCRIPTION
Add a gradle task to get the dependencies.  This is needed for setting up the development environment.