### PR TITLE
CW Issue #1067: Create the local connection in the connection manager constructor

### DIFF
--- a/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/BaseTest.java
+++ b/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/BaseTest.java
@@ -25,8 +25,8 @@ import org.eclipse.codewind.core.internal.CodewindManager;
 import org.eclipse.codewind.core.internal.FileUtil;
 import org.eclipse.codewind.core.internal.HttpUtil;
 import org.eclipse.codewind.core.internal.cli.ProjectUtil;
-import org.eclipse.codewind.core.internal.cli.TemplateUtil;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
+import org.eclipse.codewind.core.internal.connection.CodewindConnectionManager;
 import org.eclipse.codewind.core.internal.connection.ProjectTemplateInfo;
 import org.eclipse.codewind.core.internal.console.CodewindConsoleFactory;
 import org.eclipse.codewind.core.internal.console.ProjectLogInfo;
@@ -100,7 +100,7 @@ public abstract class BaseTest extends TestCase {
     	projectFolder = TestUtil.getTempFolder("codewindTest");
     	
         // Get the local Codewind connection
-        connection = CodewindManager.getManager().getLocalConnection();
+        connection = CodewindConnectionManager.getLocalConnection();
         assertNotNull("The connection should not be null.", connection);
         
         // Create a new microprofile project

--- a/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/util/CodewindUtil.java
+++ b/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/util/CodewindUtil.java
@@ -70,7 +70,7 @@ public class CodewindUtil {
 			}
 		}
 		
-		CodewindConnectionManager.removeConnection(connection.getBaseURI().toString());
+		CodewindConnectionManager.remove(connection.getBaseURI().toString());
 	}
 	
 	public static boolean waitForAppState(CodewindApplication app, AppStatus status, long timeout, long interval) {

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/BindProjectAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/BindProjectAction.java
@@ -142,7 +142,7 @@ public class BindProjectAction implements IObjectActionDelegate {
 	
 	private CodewindConnection setupConnection() {
 		final CodewindManager manager = CodewindManager.getManager();
-		CodewindConnection connection = manager.getLocalConnection();
+		CodewindConnection connection = CodewindConnectionManager.getLocalConnection();
 		if (connection != null && connection.isConnected()) {
 			return connection;
 		}
@@ -170,7 +170,7 @@ public class BindProjectAction implements IObjectActionDelegate {
 						String errorText = result.getError() != null && !result.getError().isEmpty() ? result.getError() : result.getOutput();
 						throw new InvocationTargetException(null, "There was a problem trying to start Codewind: " + errorText); //$NON-NLS-1$
 					}
-					CodewindConnection connection = CodewindManager.getManager().getLocalConnection();
+					CodewindConnection connection = CodewindConnectionManager.getLocalConnection();
 					ViewHelper.refreshCodewindExplorerView(connection);
 				} catch (TimeoutException e) {
 					throw new InvocationTargetException(e, "Codewind did not start in the expected time: " + e.getMessage()); //$NON-NLS-1$
@@ -190,6 +190,6 @@ public class BindProjectAction implements IObjectActionDelegate {
 			return null;
 		}
 
-		return manager.getLocalConnection();
+		return CodewindConnectionManager.getLocalConnection();
 	}
 }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/CodewindInstall.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/CodewindInstall.java
@@ -17,13 +17,14 @@ import java.util.concurrent.TimeoutException;
 
 import org.eclipse.codewind.core.CodewindCorePlugin;
 import org.eclipse.codewind.core.internal.CodewindManager;
-import org.eclipse.codewind.core.internal.CoreUtil;
 import org.eclipse.codewind.core.internal.CodewindManager.InstallerStatus;
+import org.eclipse.codewind.core.internal.CoreUtil;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.ProcessHelper.ProcessResult;
 import org.eclipse.codewind.core.internal.cli.InstallStatus;
 import org.eclipse.codewind.core.internal.cli.InstallUtil;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
+import org.eclipse.codewind.core.internal.connection.CodewindConnectionManager;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.codewind.ui.internal.views.ViewHelper;
@@ -266,8 +267,7 @@ public class CodewindInstall {
 				Shell shell = Display.getDefault().getActiveShell();
 				if (MessageDialog.openQuestion(shell, Messages.InstallCodewindDialogTitle,
 						NLS.bind(Messages.InstallCodewindAddProjectMessage, project.getName()))) {
-					final CodewindManager manager = CodewindManager.getManager();
-					CodewindConnection connection = manager.getLocalConnection();
+					CodewindConnection connection = CodewindConnectionManager.getLocalConnection();
 					if (connection != null && connection.isConnected()) {
 						Wizard wizard = new BindProjectWizard(connection, project.getLocation());
 						WizardLauncher.launchWizardWithoutSelection(wizard);

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RemoveConnectionAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RemoveConnectionAction.java
@@ -56,7 +56,7 @@ public class RemoveConnectionAction extends SelectionProviderAction {
 		}
 
 		try {
-			CodewindConnectionManager.removeConnection(connection.getBaseURI().toString());
+			CodewindConnectionManager.remove(connection.getBaseURI().toString());
 		} catch (Exception e) {
 			Logger.logError("Error removing connection: " + connection.getBaseURI().toString(), e); //$NON-NLS-1$
 		}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/CodewindConnectionPrefsPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/CodewindConnectionPrefsPage.java
@@ -119,7 +119,7 @@ public class CodewindConnectionPrefsPage extends PreferencePage implements IWork
 				for(int i : selected) {
 					// The URL is in the 0th column of the table
 					String url = connectionsTable.getItem(i).getText(0);
-					CodewindConnectionManager.removeConnection(url);
+					CodewindConnectionManager.remove(url);
 				}
 
 				refreshConnectionsList();

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectPage.java
@@ -26,6 +26,7 @@ import org.eclipse.codewind.core.internal.cli.InstallStatus;
 import org.eclipse.codewind.core.internal.cli.InstallUtil;
 import org.eclipse.codewind.core.internal.cli.TemplateUtil;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
+import org.eclipse.codewind.core.internal.connection.CodewindConnectionManager;
 import org.eclipse.codewind.core.internal.connection.ProjectTemplateInfo;
 import org.eclipse.codewind.core.internal.connection.RepositoryInfo;
 import org.eclipse.codewind.core.internal.constants.ProjectLanguage;
@@ -657,13 +658,13 @@ public class NewCodewindProjectPage extends WizardPage {
 	
 	private void setupConnection() {
 		final CodewindManager manager = CodewindManager.getManager();
-		connection = manager.getLocalConnection();
+		connection = CodewindConnectionManager.getLocalConnection();
 		if (connection != null && connection.isConnected()) {
 			return;
 		}
 		InstallStatus status = manager.getInstallStatus();
 		if (status.isStarted()) {
-			connection = manager.getLocalConnection();
+			connection = CodewindConnectionManager.getLocalConnection();
 			return;
 		}
 		if (!status.isInstalled()) {
@@ -683,7 +684,7 @@ public class NewCodewindProjectPage extends WizardPage {
 						String errorText = result.getError() != null && !result.getError().isEmpty() ? result.getError() : result.getOutput();
 						throw new InvocationTargetException(null, "There was a problem while trying to start Codewind: " + errorText); //$NON-NLS-1$
 					}
-					connection = manager.getLocalConnection();
+					connection = CodewindConnectionManager.getLocalConnection();
 					ViewHelper.refreshCodewindExplorerView(connection);
 				} catch (IOException e) {
 					throw new InvocationTargetException(e, "An error occurred trying to start Codewind: " + e.getMessage()); //$NON-NLS-1$


### PR DESCRIPTION
Create the local connection in the CodewindConnectionManager constructor so that it is there before the overview pages get restored.  Also got rid of a duplicate remove method in CodewindConnectionManager.