### PR TITLE
CW Issue #1067: Create the local connection in the CodewindConnectionManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Prerequisites
 Complete the installation:
 1. Install [Codewind from the Eclipse Marketplace](https://marketplace.eclipse.org/content/codewind).
 2. Open the **Codewind Explorer** view. Go to **Window**>**Show View**>**Other…**>**Codewind**>**Codewind Explorer**.
-3. Double-click the **Codewind** entry in the view to finish installing Codewind. The download is approximately 1 GB. For more information, see [Installing Codewind for Eclipse](https://www.eclipse.org/codewind/mdt-eclipse-installinfo.html).
+3. Double-click the **Local** entry in the view to finish installing Codewind. The download is approximately 1 GB. For more information, see [Installing Codewind for Eclipse](https://www.eclipse.org/codewind/mdt-eclipse-installinfo.html).
 
 ## Using Codewind for Eclipse
-Right-click the **Local Projects** entry in the view to create new projects or add existing projects to Codewind. After a project is created or added, it displays in the **Codewind Explorer** view. Right-click the project to see the available actions.
+Right-click the **Local** entry in the view to create new projects or add existing projects to Codewind. After a project is created or added, it displays in the **Codewind Explorer** view. Right-click the project to see the available actions.
 
 [Features:](https://www.eclipse.org/codewind/mdteclipsemanagingprojects.html)</br>
 - **Open Application**: Opens the application in the default Eclipse browser. This action is only available when the application is running or debugging.
@@ -38,8 +38,8 @@ Right-click the **Local Projects** entry in the view to create new projects or a
 - **Build**: Initiate a build of your project. This action is not available if a build is already running. For more information, see [Building Codewind projects](https://www.eclipse.org/codewind/mdteclipsebuildproject.html).
 - **Disable Auto Build**: Use this to disable automatic builds if you are making a lot of changes and don't want builds to be triggered until you are done. This action is available only when auto build is enabled.
 - **Enable Auto Build**: Use this to re-enable automatic builds whenever a change is made. This action is available only when auto build is disabled.
-- **Remove**: Removes a project. This action removes the project from Codewind. You can then use Eclipse to delete the project from the Eclipse workspace and the file system.
-- **Refresh**: If the project gets out of sync, use this option to refresh it. To refresh all projects, right-click the **Projects (Local)** item in the **Codewind Explorer** view and select **Refresh**.
+- **Remove**: Removes a project. This action removes the project from Codewind and optionally deletes the project files from the file system.
+- **Refresh**: If the project gets out of sync, use this option to refresh it. To refresh all projects, right-click the **Local** item in the **Codewind Explorer** view and select **Refresh**.
 
 ## Enabling debug logs
 1. Create an `.options` file in your Eclipse install directory, the same directory with the `eclipse` executable. Include the following content in the new file:

--- a/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/BaseTest.java
+++ b/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/BaseTest.java
@@ -25,8 +25,8 @@ import org.eclipse.codewind.core.internal.CodewindManager;
 import org.eclipse.codewind.core.internal.FileUtil;
 import org.eclipse.codewind.core.internal.HttpUtil;
 import org.eclipse.codewind.core.internal.cli.ProjectUtil;
-import org.eclipse.codewind.core.internal.cli.TemplateUtil;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
+import org.eclipse.codewind.core.internal.connection.CodewindConnectionManager;
 import org.eclipse.codewind.core.internal.connection.ProjectTemplateInfo;
 import org.eclipse.codewind.core.internal.console.CodewindConsoleFactory;
 import org.eclipse.codewind.core.internal.console.ProjectLogInfo;
@@ -100,7 +100,7 @@ public abstract class BaseTest extends TestCase {
     	projectFolder = TestUtil.getTempFolder("codewindTest");
     	
         // Get the local Codewind connection
-        connection = CodewindManager.getManager().getLocalConnection();
+        connection = CodewindConnectionManager.getLocalConnection();
         assertNotNull("The connection should not be null.", connection);
         
         // Create a new microprofile project

--- a/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/util/CodewindUtil.java
+++ b/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/util/CodewindUtil.java
@@ -70,7 +70,7 @@ public class CodewindUtil {
 			}
 		}
 		
-		CodewindConnectionManager.removeConnection(connection.getBaseURI().toString());
+		CodewindConnectionManager.remove(connection.getBaseURI().toString());
 	}
 	
 	public static boolean waitForAppState(CodewindApplication app, AppStatus status, long timeout, long interval) {

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/BindProjectAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/BindProjectAction.java
@@ -142,7 +142,7 @@ public class BindProjectAction implements IObjectActionDelegate {
 	
 	private CodewindConnection setupConnection() {
 		final CodewindManager manager = CodewindManager.getManager();
-		CodewindConnection connection = manager.getLocalConnection();
+		CodewindConnection connection = CodewindConnectionManager.getLocalConnection();
 		if (connection != null && connection.isConnected()) {
 			return connection;
 		}
@@ -170,7 +170,7 @@ public class BindProjectAction implements IObjectActionDelegate {
 						String errorText = result.getError() != null && !result.getError().isEmpty() ? result.getError() : result.getOutput();
 						throw new InvocationTargetException(null, "There was a problem trying to start Codewind: " + errorText); //$NON-NLS-1$
 					}
-					CodewindConnection connection = CodewindManager.getManager().getLocalConnection();
+					CodewindConnection connection = CodewindConnectionManager.getLocalConnection();
 					ViewHelper.refreshCodewindExplorerView(connection);
 				} catch (TimeoutException e) {
 					throw new InvocationTargetException(e, "Codewind did not start in the expected time: " + e.getMessage()); //$NON-NLS-1$
@@ -190,6 +190,6 @@ public class BindProjectAction implements IObjectActionDelegate {
 			return null;
 		}
 
-		return manager.getLocalConnection();
+		return CodewindConnectionManager.getLocalConnection();
 	}
 }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/CodewindInstall.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/CodewindInstall.java
@@ -17,13 +17,14 @@ import java.util.concurrent.TimeoutException;
 
 import org.eclipse.codewind.core.CodewindCorePlugin;
 import org.eclipse.codewind.core.internal.CodewindManager;
-import org.eclipse.codewind.core.internal.CoreUtil;
 import org.eclipse.codewind.core.internal.CodewindManager.InstallerStatus;
+import org.eclipse.codewind.core.internal.CoreUtil;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.ProcessHelper.ProcessResult;
 import org.eclipse.codewind.core.internal.cli.InstallStatus;
 import org.eclipse.codewind.core.internal.cli.InstallUtil;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
+import org.eclipse.codewind.core.internal.connection.CodewindConnectionManager;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.codewind.ui.internal.views.ViewHelper;
@@ -266,8 +267,7 @@ public class CodewindInstall {
 				Shell shell = Display.getDefault().getActiveShell();
 				if (MessageDialog.openQuestion(shell, Messages.InstallCodewindDialogTitle,
 						NLS.bind(Messages.InstallCodewindAddProjectMessage, project.getName()))) {
-					final CodewindManager manager = CodewindManager.getManager();
-					CodewindConnection connection = manager.getLocalConnection();
+					CodewindConnection connection = CodewindConnectionManager.getLocalConnection();
 					if (connection != null && connection.isConnected()) {
 						Wizard wizard = new BindProjectWizard(connection, project.getLocation());
 						WizardLauncher.launchWizardWithoutSelection(wizard);

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RemoveConnectionAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RemoveConnectionAction.java
@@ -56,7 +56,7 @@ public class RemoveConnectionAction extends SelectionProviderAction {
 		}
 
 		try {
-			CodewindConnectionManager.removeConnection(connection.getBaseURI().toString());
+			CodewindConnectionManager.remove(connection.getBaseURI().toString());
 		} catch (Exception e) {
 			Logger.logError("Error removing connection: " + connection.getBaseURI().toString(), e); //$NON-NLS-1$
 		}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/CodewindConnectionPrefsPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/CodewindConnectionPrefsPage.java
@@ -119,7 +119,7 @@ public class CodewindConnectionPrefsPage extends PreferencePage implements IWork
 				for(int i : selected) {
 					// The URL is in the 0th column of the table
 					String url = connectionsTable.getItem(i).getText(0);
-					CodewindConnectionManager.removeConnection(url);
+					CodewindConnectionManager.remove(url);
 				}
 
 				refreshConnectionsList();

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectPage.java
@@ -26,6 +26,7 @@ import org.eclipse.codewind.core.internal.cli.InstallStatus;
 import org.eclipse.codewind.core.internal.cli.InstallUtil;
 import org.eclipse.codewind.core.internal.cli.TemplateUtil;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
+import org.eclipse.codewind.core.internal.connection.CodewindConnectionManager;
 import org.eclipse.codewind.core.internal.connection.ProjectTemplateInfo;
 import org.eclipse.codewind.core.internal.connection.RepositoryInfo;
 import org.eclipse.codewind.core.internal.constants.ProjectLanguage;
@@ -657,13 +658,13 @@ public class NewCodewindProjectPage extends WizardPage {
 	
 	private void setupConnection() {
 		final CodewindManager manager = CodewindManager.getManager();
-		connection = manager.getLocalConnection();
+		connection = CodewindConnectionManager.getLocalConnection();
 		if (connection != null && connection.isConnected()) {
 			return;
 		}
 		InstallStatus status = manager.getInstallStatus();
 		if (status.isStarted()) {
-			connection = manager.getLocalConnection();
+			connection = CodewindConnectionManager.getLocalConnection();
 			return;
 		}
 		if (!status.isInstalled()) {
@@ -683,7 +684,7 @@ public class NewCodewindProjectPage extends WizardPage {
 						String errorText = result.getError() != null && !result.getError().isEmpty() ? result.getError() : result.getOutput();
 						throw new InvocationTargetException(null, "There was a problem while trying to start Codewind: " + errorText); //$NON-NLS-1$
 					}
-					connection = manager.getLocalConnection();
+					connection = CodewindConnectionManager.getLocalConnection();
 					ViewHelper.refreshCodewindExplorerView(connection);
 				} catch (IOException e) {
 					throw new InvocationTargetException(e, "An error occurred trying to start Codewind: " + e.getMessage()); //$NON-NLS-1$


### PR DESCRIPTION
Fixes #https://github.com/eclipse/codewind/issues/1067

Create the local connection in the CodewindConnectionManager so that it is there before the overview pages get restored.  Also deleted a duplicate remove connection method in CodewindConnectionManager.

