### PR TITLE
CW Issue #1093: Add bash to the project languages

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectLanguage.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectLanguage.java
@@ -17,6 +17,7 @@ public enum ProjectLanguage {
 	LANGUAGE_SWIFT("swift", "Swift"),
 	LANGUAGE_PYTHON("python", "Python"),
 	LANGUAGE_GO("go", "Go"),
+	LANGUAGE_BASH("bash", "Bash"),
 	LANGUAGE_UNKNOWN("unknown", "Unknown");
 	
 	private final String id;


### PR DESCRIPTION
Add bash to the project languages. Issue https://github.com/eclipse/codewind/issues/1094 opened to improve how project types and languages handled.