### PR TITLE
CW Issue #961: show results of workspace migration in a pop up dialog

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/UpgradeResult.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/UpgradeResult.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *	 IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.codewind.core.internal.cli;
+
+import org.eclipse.codewind.core.internal.connection.JSONObjectResult;
+import org.eclipse.codewind.core.internal.messages.Messages;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class UpgradeResult extends JSONObjectResult {
+	
+	private static String FAILED_KEY = "failed";
+	private static String MIGRATED_KEY = "migrated";
+	private static String ERROR_KEY = "error";
+	private static String PROJECT_NAME_KEY = "projectName";
+	
+	public UpgradeResult(JSONObject result) {
+		super(result, "workspace upgrade");
+	}
+	
+	public String getFormattedResult() throws JSONException {
+		JSONArray migrated = getArray(MIGRATED_KEY);
+		JSONArray failed = getArray(FAILED_KEY);
+		if ((migrated == null || migrated.length() == 0) && (failed == null || failed.length() == 0)) {
+			return null;
+		}
+		
+		StringBuilder builder = new StringBuilder();
+		
+		if (migrated != null && migrated.length() > 0) {
+			builder.append(Messages.UpgradeResultMigrated + "\n");
+			builder.append("  ");
+			boolean start = true;
+			for (int i = 0; i < migrated.length(); i++) {
+				if (start) {
+					start = false;
+				} else {
+					builder.append(", ");
+				}
+				builder.append(migrated.get(i));
+			}
+		}
+		
+		if (failed != null && failed.length() > 0) {
+			if (builder.length() > 0) {
+				builder.append("\n");
+			}
+			builder.append(Messages.UpgradeResultNotMigrated + "\n");
+			builder.append("  ");
+			boolean start = true;
+			for (int i = 0; i < failed.length(); i++) {
+				if (start) {
+					start = false;
+				} else {
+					builder.append("\n  ");
+				}
+				JSONObject obj = failed.getJSONObject(i);
+				String name = obj.getString(PROJECT_NAME_KEY);
+				String error = obj.getString(ERROR_KEY);
+				builder.append(name + " (" + error + ")");
+			}
+		}
+		
+		return builder.toString();
+	}
+
+}

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/JSONObjectResult.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/JSONObjectResult.java
@@ -87,6 +87,20 @@ public abstract class JSONObjectResult {
 		}
 		return value;
 	}
+	
+	protected JSONArray getArray(String key) {
+		JSONArray value = null;
+		if (result.has(key)) {
+			try {
+				value = result.getJSONArray(key);
+			} catch (JSONException e) {
+				Logger.logError("An error occurred retrieving the value from the " + type + " object for key: " + key, e);
+			}
+		} else {
+			Logger.logError("The " + type + " object did not have the expected key: " + key);
+		}
+		return value;
+	}
 
 	@Override
 	public String toString() {

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
@@ -94,6 +94,9 @@ public class Messages extends NLS {
 	public static String DockerTypeDisplayName;
 	
 	public static String ProcessHelperUnknownError;
+	
+	public static String UpgradeResultMigrated;
+	public static String UpgradeResultNotMigrated;
 
 	static {
 		// initialize resource bundle

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
@@ -87,3 +87,6 @@ ProjectSettingsUpdateErrorTitle=Project settings update error
 DockerTypeDisplayName=Other (Codewind Basic Container)
 
 ProcessHelperUnknownError=Unknown error
+
+UpgradeResultMigrated=The following projects were successfully migrated:
+UpgradeResultNotMigrated=Problems were encountered migrating these projects. Try manually adding them as existing projects to Codewind:

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -150,6 +150,7 @@ public class Messages extends NLS {
 	public static String CodewindInstallTimeout;
 	public static String CodewindUninstallTimeout;
 	public static String WorkspaceUpgradeError;
+	public static String WorkspaceUpgradeTitle;
 	
 	public static String UpdateCodewindDialogTitle;
 	public static String UpdateCodewindDialogMsg;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -164,10 +164,11 @@ CodewindStartTimeout=Codewind did not start in the expected time. Try increasing
 CodewindStopTimeout=Codewind did not stop in the expected time. Try increasing the timeout in the Codewind preferences page.
 CodewindInstallTimeout=Codewind did not install in the expected time. Try increasing the timeout in the Codewind preferences page.
 CodewindUninstallTimeout=Codewind did not uninstall in the expected time. Try increasing the timeout in the Codewind preferences page.
-WorkspaceUpgradeError=An error occurred trying to upgrade the Codewind workspace. Try manually adding your existing projects to Codewind.
+WorkspaceUpgradeError=An error occurred trying to migrate the Codewind workspace. Try manually adding your existing projects to Codewind.
+WorkspaceUpgradeTitle=Workspace Migration for {0}
 
 UpdateCodewindDialogTitle=Codewind Update
-UpdateCodewindDialogMsg=This will remove the unsupported version of Codewind and install, and start the supported version of Codewind. It will also upgrade your Codewind projects for the new version if necessary. Do you want to continue?
+UpdateCodewindDialogMsg=This will remove the unsupported version of Codewind and install, and start the supported version of Codewind. It will also migrate your Codewind projects for the new version if necessary. Do you want to continue?
 
 SelectProjectTypePageName=Select Project Type
 SelectProjectTypePageTitle=Project Type Selection


### PR DESCRIPTION
Updated the code for workspace upgrade to read the JSON result if the exit code is 0 and display it to the user.