### PR TITLE
Fix attempt to remove local connection on shutdown

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
@@ -177,8 +177,8 @@ public class CodewindConnection {
 	 */
 	public void close() {
 		disconnect();
-		Logger.log("Removing connection: " + this); //$NON-NLS-1$
-		if (conid != null) {
+		if (!isLocal() && conid != null) {
+			Logger.log("Removing connection: " + this); //$NON-NLS-1$
 			try {
 				ConnectionUtil.removeConnection(name, conid, new NullProgressMonitor());
 			} catch (Exception e) {


### PR DESCRIPTION
When shutting down Eclipse, the following errors are written to the log:
```
!ENTRY org.eclipse.codewind.core 4 0 2019-11-20 10:57:54.188
!MESSAGE [ERROR ConnectionUtil.removeConnection:88] Connection remove failed with rc: 1 and error: time="2019-11-20T10:57:53-05:00" level=info msg="Local is a required connection and must not be removed"

!ENTRY org.eclipse.codewind.core 4 0 2019-11-20 10:57:54.189
!MESSAGE [ERROR CodewindConnection.close:185] An error occurred trying to de-register the connection: CodewindConnection @ name=Local baseUrl=unknown conid=local
```
This change prevents the attempt to remove the local connection in CodewindConnection.close()

Signed-off-by: John Pitman <jspitman@ca.ibm.com>