### PR TITLE
CW Issue #839: Improvements to the edit connection dialog

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -61,6 +61,7 @@ public class Messages extends NLS {
 	public static String CodewindConnectionComposite_InvalidUrlError;
 	public static String CodewindConnectionComposite_UrlInUseError;
 	public static String CodewindConnectionComposite_MissingConnDetailsError;
+	public static String CodewindConnectionComposite_NoPasswordForUpdateError;
 	public static String CodewindConnectionComposite_TestConnMsg;
 	public static String CodewindConnectionComposite_TestConnectionJobLabel;
 	public static String CodewindConnectionComposite_ConnectSucceeded;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -54,6 +54,7 @@ CodewindConnectionComposite_ConnNameInUseError=The name {0} is already used for 
 CodewindConnectionComposite_InvalidUrlError=The url is not valid: {0}
 CodewindConnectionComposite_UrlInUseError=The {0} connection is already using url: {1}
 CodewindConnectionComposite_MissingConnDetailsError=Fill in all of the connection details fields.
+CodewindConnectionComposite_NoPasswordForUpdateError=Fill in the password to authorize the changes.
 CodewindConnectionComposite_TestConnMsg=Click `Test Connection` to validate the connection.
 CodewindConnectionComposite_TestConnectionJobLabel=Connecting to Codewind at: {0}
 CodewindConnectionComposite_ConnectSucceeded=Connecting to {0} succeeded.
@@ -421,5 +422,5 @@ RepoListErrorMsg=An error occurred while trying to get the list of template sour
 
 EditConnectionDialogShell=Edit Connection
 EditConnectionDialogTitle=Edit a connection
-EditConnectionDialogMessage=Modify the {0} connection.
+EditConnectionDialogMessage=Modify the {0} connection. The password field must be filled in to authorize the changes even if the password does not need to be updated.
 UpdateConnectionJobLabel=Updating connection: {0}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/CodewindConnectionComposite.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/CodewindConnectionComposite.java
@@ -162,7 +162,13 @@ public class CodewindConnectionComposite extends Composite {
 		}
 
 		// Check that all of the connection fields are filled in
-		if (url.isEmpty() || user.isEmpty() || pass.isEmpty()) {
+		if (url.isEmpty() || user.isEmpty()) {
+			return Messages.CodewindConnectionComposite_MissingConnDetailsError;
+		}
+		if (pass.isEmpty()) {
+			if (isUpdate) {
+				return Messages.CodewindConnectionComposite_NoPasswordForUpdateError;
+			}
 			return Messages.CodewindConnectionComposite_MissingConnDetailsError;
 		}
 		

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/EditConnectionDialog.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/EditConnectionDialog.java
@@ -16,7 +16,6 @@ import java.lang.reflect.InvocationTargetException;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.messages.Messages;
-import org.eclipse.codewind.ui.internal.prefs.RepositoryManagementComposite;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.jobs.Job;
@@ -27,6 +26,7 @@ import org.eclipse.jface.operation.ModalContext;
 import org.eclipse.jface.wizard.ProgressMonitorPart;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -61,13 +61,11 @@ public class EditConnectionDialog extends TitleAreaDialog implements CompositeCo
 		setMessage(NLS.bind(Messages.EditConnectionDialogMessage, connection.getName()));
 		
 		Composite content = (Composite) super.createDialogArea(parent);
-		content.setLayout(new GridLayout());
+		content.setLayout(new GridLayout(1, false));
 		content.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, true));
 		
 		connectionComp = new CodewindConnectionComposite(content, this, connection);
-		GridData data = new GridData(SWT.FILL, SWT.FILL, true, true);
-		data.widthHint = 250;
-		connectionComp.setLayoutData(data);
+		connectionComp.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		
 		GridLayout layout = new GridLayout();
 		layout.numColumns = 1;
@@ -78,6 +76,12 @@ public class EditConnectionDialog extends TitleAreaDialog implements CompositeCo
 		progressMon.setVisible(false);
 		
 		return parent;
+	}
+
+	@Override
+	protected void createButtonsForButtonBar(Composite parent) {
+		super.createButtonsForButtonBar(parent);
+		getButton(IDialogConstants.OK_ID).setEnabled(false);
 	}
 
 	@Override
@@ -94,7 +98,7 @@ public class EditConnectionDialog extends TitleAreaDialog implements CompositeCo
 
 	@Override
 	public void update() {
-		getButton(IDialogConstants.OK_ID) .setEnabled(connectionComp.canFinish());
+		getButton(IDialogConstants.OK_ID).setEnabled(connectionComp.canFinish());
 	}
 
 	@Override
@@ -106,5 +110,11 @@ public class EditConnectionDialog extends TitleAreaDialog implements CompositeCo
 			progressMon.done();
 			progressMon.setVisible(false);
 		}
+	}
+	
+	@Override
+	protected Point getInitialSize() {
+		Point point = super.getInitialSize();
+		return new Point(650, point.y);
 	}
 }


### PR DESCRIPTION
- Improved message so user knows why they need to fill in the password
- Message is long now so set the dialog size to keep it from being the length of the message
- Make sure the OK button is disabled at the start