### PR TITLE
CW Issue #1330: Add the language to the project validation page

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/IDEUtil.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/IDEUtil.java
@@ -75,6 +75,14 @@ public class IDEUtil {
 		text.setStyleRange(range);
 	}
     
+    public static void setBold(StyledText text, String str) {
+		StyleRange range = new StyleRange();
+		range.start = text.getText().indexOf(str);
+		range.length = str.length();
+		range.fontStyle = SWT.BOLD;
+		text.setStyleRange(range);
+	}
+    
     public static void normalizeBackground(Control control, Control parent) {
     	control.setBackground(parent.getBackground());
     	control.setForeground(parent.getForeground());

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -218,7 +218,8 @@ public class Messages extends NLS {
 	public static String ProjectValidationPageDescription;
 	public static String ProjectValidationPageMsg;
 	public static String ProjectValidationPageFailMsg;
-	public static String ProjectValidationPageProjectTypeLabel;
+	public static String ProjectValidationPageTypeLabel;
+	public static String ProjectValidationPageLanguageLabel;
 	public static String ProjectValidationTask;
 	
 	public static String RestartInDebugMode;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -212,7 +212,8 @@ ProjectValidationPageTitle=Confirm Project Type
 ProjectValidationPageDescription=Confirm the detected project type
 ProjectValidationPageMsg=If the detected project type below is correct for project {0}, click Finish. If not, continue to the next page to select the project type.
 ProjectValidationPageFailMsg=The project type could not be determined automatically. Continue to the next page to select the project type manually.
-ProjectValidationPageProjectTypeLabel=Project type:
+ProjectValidationPageTypeLabel=Type: {0}
+ProjectValidationPageLanguageLabel=Language: {0}
 ProjectValidationTask=Validating project: {0}
 
 RestartInDebugMode=Restart in &Debug Mode

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectValidationPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectValidationPage.java
@@ -17,6 +17,7 @@ import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.cli.ProjectUtil;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
 import org.eclipse.codewind.core.internal.constants.ProjectInfo;
+import org.eclipse.codewind.core.internal.constants.ProjectLanguage;
 import org.eclipse.codewind.ui.internal.IDEUtil;
 import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.core.runtime.IPath;
@@ -41,7 +42,7 @@ public class ProjectValidationPage extends WizardPage {
 	private IPath projectPath;
 	private ProjectInfo projectInfo;
 	private Text validateMsg;
-	private StyledText typeText;
+	private StyledText typeText, languageText;
 
 	protected ProjectValidationPage(BindProjectWizard wizard, CodewindConnection connection, IPath projectPath) {
 		super(Messages.ProjectValidationPageName);
@@ -76,6 +77,13 @@ public class ProjectValidationPage extends WizardPage {
 		data.horizontalIndent = 20;
 		typeText.setLayoutData(data);
 		IDEUtil.normalizeBackground(typeText, composite);
+		
+		languageText = new StyledText(composite, SWT.READ_ONLY);
+		languageText.setText("");
+		data = new GridData(GridData.FILL, GridData.CENTER, true, false);
+		data.horizontalIndent = 20;
+		languageText.setLayoutData(data);
+		IDEUtil.normalizeBackground(languageText, composite);
 		
 		setProjectPath(projectPath, false);
 
@@ -124,13 +132,23 @@ public class ProjectValidationPage extends WizardPage {
 		wizard.setProjectInfo(projectInfo);
 		if (projectInfo != null) {
 			validateMsg.setText(NLS.bind(Messages.ProjectValidationPageMsg, projectPath.lastSegment()));
-			typeText.setText(projectInfo.type.getDisplayName());
-			IDEUtil.setBold(typeText);
+			typeText.setText(NLS.bind(Messages.ProjectValidationPageTypeLabel, projectInfo.type.getDisplayName()));
+			IDEUtil.setBold(typeText, projectInfo.type.getDisplayName());
 			IDEUtil.normalizeBackground(typeText, typeText.getParent());
 			typeText.setVisible(true);
+			
+			if (projectInfo.language != ProjectLanguage.LANGUAGE_UNKNOWN) {
+				languageText.setText(NLS.bind(Messages.ProjectValidationPageLanguageLabel, projectInfo.language.getDisplayName()));
+				IDEUtil.setBold(languageText, projectInfo.language.getDisplayName());
+				IDEUtil.normalizeBackground(languageText, languageText.getParent());
+				languageText.setVisible(true);
+			} else {
+				languageText.setVisible(false);
+			}
 		} else {
 			validateMsg.setText(Messages.ProjectValidationPageFailMsg);
 			typeText.setVisible(false);
+			languageText.setVisible(false);
 		}
 		
 		int width = validateMsg.getParent().getClientArea().width;


### PR DESCRIPTION
Fixes #https://github.com/eclipse/codewind/issues/1330

Now that the validation picks up the language, include it in the project validation page.