### PR TITLE
CW #1309 - [Filewatcherd] Filewatcher unable to connect to secure PFE (via HTTP/WebSocket) without using an auth token acquired through CWCTL

### DIFF
--- a/dev/org.eclipse.codewind.core/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.core/META-INF/MANIFEST.MF
@@ -24,7 +24,8 @@ Export-Package: io.socket.client,
  org.eclipse.codewind.core.internal.console,
  org.eclipse.codewind.core.internal.constants,
  org.json
-Import-Package: org.eclipse.codewind.filewatchers.eclipse
+Import-Package: org.eclipse.codewind.filewatchers.core,
+ org.eclipse.codewind.filewatchers.eclipse
 Bundle-ClassPath: .,
  lib/engine.io-client-1.0.0.jar,
  lib/org.json_1.0.0.v201011060100.jar,

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
@@ -131,7 +131,8 @@ public class CodewindConnection {
 				}
 				return Optional.empty();
 			}
-		});
+		}, null);
+		
 		if (mon.isCanceled()) {
 			disconnect();
 			return;

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
@@ -39,6 +39,7 @@ import org.eclipse.codewind.core.internal.connection.ConnectionEnv.TektonDashboa
 import org.eclipse.codewind.core.internal.console.ProjectLogInfo;
 import org.eclipse.codewind.core.internal.constants.CoreConstants;
 import org.eclipse.codewind.core.internal.messages.Messages;
+import org.eclipse.codewind.filewatchers.core.IAuthTokenProvider;
 import org.eclipse.codewind.filewatchers.eclipse.CodewindFilewatcherdConnection;
 import org.eclipse.codewind.filewatchers.eclipse.ICodewindProjectTranslator;
 import org.eclipse.core.resources.IProject;
@@ -131,7 +132,7 @@ public class CodewindConnection {
 				}
 				return Optional.empty();
 			}
-		}, null);
+		}, null); // TODO: IDE team to provide an 'IAuthTokenProvider' here 
 		
 		if (mon.isCanceled()) {
 			disconnect();

--- a/dev/org.eclipse.codewind.filewatchers.core/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.filewatchers.core/META-INF/MANIFEST.MF
@@ -14,5 +14,4 @@ Bundle-ClassPath: .,
  lib/websocket-api-9.4.23.v20191118.jar,
  lib/websocket-client-9.4.23.v20191118.jar,
  lib/websocket-common-9.4.23.v20191118.jar
-Export-Package: org.eclipse.codewind.filewatchers.core,
- org.eclipse.codewind.filewatchers.core.internal
+Export-Package: org.eclipse.codewind.filewatchers.core

--- a/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/FWAuthToken.java
+++ b/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/FWAuthToken.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.codewind.filewatchers.core;
+
+/**
+ * Immutable authorization token for use in HTTP(S) requests and WebSocket
+ * connections
+ */
+public class FWAuthToken {
+
+	private final String accessToken;
+
+	private final String tokenType;
+
+	public FWAuthToken(String token, String tokenType) {
+		if (token == null || tokenType == null) {
+			throw new IllegalArgumentException("Null args in FWAuthToken: " + token + " " + tokenType);
+		}
+
+		this.accessToken = token;
+		this.tokenType = tokenType;
+	}
+
+	public String getAccessToken() {
+		return accessToken;
+	}
+
+	public String getTokenType() {
+		return tokenType;
+	}
+
+	private String key() {
+		return accessToken + "/" + tokenType;
+	}
+
+	@Override
+	public String toString() {
+		return key();
+	}
+
+	@Override
+	public int hashCode() {
+		return key().hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof FWAuthToken)) {
+			return false;
+		}
+
+		FWAuthToken other = (FWAuthToken) obj;
+
+		return other.key().equals(this.key());
+	}
+
+}

--- a/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/IAuthTokenProvider.java
+++ b/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/IAuthTokenProvider.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.codewind.filewatchers.core;
+
+/**
+ * The Codewind IDE classes should extends this interface to provide
+ * filewatcherd with secure authentication tokens from the IDE.
+ * 
+ * This class was created as part of issue codewind/1309.
+ */
+public interface IAuthTokenProvider {
+
+	/**
+	 * Return the latest auth token; return null if an auth token is not available.
+	 * 
+	 * This method should be non-blocking (eg it should return null or stale data,
+	 * rather then block on issuing a new I/O or CWCTL request to acquire a new
+	 * token.)
+	 */
+	public FWAuthToken getLatestAuthToken();
+
+	/**
+	 * Inform the IDE that the server told us that our current token is invalid, at
+	 * which point the IDE should then re-acquire/refresh it on a separate thread.
+	 * After FWd informs the IDE, the new value should be available to the FWd via a
+	 * call to getLatestAuthToken() after some short period of time.
+	 * 
+	 * Filewatcher to call `informReceivedInvalidAuthToken(...)` ONLY ONCE for a
+	 * given invalid token (eg NOT every time the server informs us.)
+	 */
+	public void informReceivedInvalidAuthToken(FWAuthToken badToken);
+
+}

--- a/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/AuthTokenWrapper.java
+++ b/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/AuthTokenWrapper.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.codewind.filewatchers.core.internal;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Optional;
+
+import org.eclipse.codewind.filewatchers.core.FWAuthToken;
+import org.eclipse.codewind.filewatchers.core.FWLogger;
+import org.eclipse.codewind.filewatchers.core.IAuthTokenProvider;
+
+/**
+ * AuthTokenWrapper is the conduit through the internal filewatcher codebase
+ * requests secure authentication tokens from the IDE. In cases where the
+ * authTokenProvider is null (eg is secure auth is not required), the methods of
+ * this class are no-ops.
+ * 
+ * This class is thread-safe.
+ * 
+ * This class was created as part of issue codewind/1309.
+ */
+public class AuthTokenWrapper {
+
+	private static final int KEEP_LAST_X_STALE_KEYS = 10;
+
+	private static final FWLogger log = FWLogger.getInstance();
+
+	private final Object lock = new Object();
+
+	/**
+	 * Contains an ordered (descending by creation time) list of invalids keys, with
+	 * at most KEEP_LAST_X_STALE_KEYS keys.
+	 */
+	private final Deque<FWAuthToken> recentInvalidKeysQueue_synch_lock = new ArrayDeque<>();
+
+	/**
+	 * Contains invalid keys; used as a fast path to determine if a given key is
+	 * already invalid. The should be at most KEEP_LAST_X_STALE_KEYS here.
+	 */
+	private final HashSet<FWAuthToken> invalidKeysMap_synch_lock = new HashSet<>();
+
+	/**
+	 * Retrieve the auth token from the IDE, if available; null if the connection
+	 * does not need an auth token.
+	 */
+	private final IAuthTokenProvider authTokenProvider;
+
+	public AuthTokenWrapper(IAuthTokenProvider authTokenProvider /* nullable */ ) {
+
+		this.authTokenProvider = authTokenProvider;
+	}
+
+	/** Retrieve the latest token from the IDE */
+	public Optional<FWAuthToken> getLatestToken() {
+		if (authTokenProvider == null) {
+			return Optional.empty();
+		}
+
+		FWAuthToken token = authTokenProvider.getLatestAuthToken();
+		if (token == null) {
+			return Optional.empty();
+		}
+
+		log.logInfo("IDE returned a new security token to filewatcher: " + digest(token));
+
+		return Optional.of(token);
+
+	}
+
+	/** Inform the IDE when a token is rejected. */
+	public void informBadToken(FWAuthToken token) {
+
+		if (authTokenProvider == null || token == null) {
+			return;
+		}
+
+		synchronized (lock) {
+			// We've already reported this key as invalid, so just return it
+			if (invalidKeysMap_synch_lock.contains(token)) {
+				log.logInfo("Filewatcher informed us of a bad token, but we've already reported it to the IDE: "
+						+ digest(token));
+				return;
+			}
+
+			// We have a new token that we have not previously reported as invalid.
+
+			invalidKeysMap_synch_lock.add(token);
+			recentInvalidKeysQueue_synch_lock.offer(token);
+
+			while (recentInvalidKeysQueue_synch_lock.size() > KEEP_LAST_X_STALE_KEYS) {
+				FWAuthToken keyToRemove = recentInvalidKeysQueue_synch_lock.poll();
+				invalidKeysMap_synch_lock.remove(keyToRemove);
+			}
+
+		}
+
+		log.logInfo("Filewatcher informed us of a new invalid token, so we've already reported it to the IDE: "
+				+ digest(token));
+
+	}
+
+	/**
+	 * Return a representation of the token that is at most 32 characters long, so
+	 * as not to overwhelm the log file.
+	 */
+	private static String digest(FWAuthToken token) {
+		if (token == null) {
+			return null;
+		}
+
+		String key = token.getAccessToken();
+		if (key == null) {
+			return null;
+		}
+
+		return key.substring(0, Math.min(key.length(), 32));
+	}
+
+}

--- a/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/AuthTokenWrapper.java
+++ b/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/AuthTokenWrapper.java
@@ -105,6 +105,8 @@ public class AuthTokenWrapper {
 
 		}
 
+		authTokenProvider.informReceivedInvalidAuthToken(token);
+
 		log.logInfo("Filewatcher informed us of a new invalid token, so we've already reported it to the IDE: "
 				+ digest(token));
 

--- a/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/HttpGetStatusThread.java
+++ b/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/HttpGetStatusThread.java
@@ -63,9 +63,12 @@ public class HttpGetStatusThread extends Thread {
 
 	private final Object lock = new Object();
 
-	public HttpGetStatusThread(String url, Filewatcher parent) {
+	private final AuthTokenWrapper authTokenWrapper;
+
+	public HttpGetStatusThread(String url, Filewatcher parent, AuthTokenWrapper authTokenWrapper) {
 		this.parent = parent;
 		this.baseUrl = url;
+		this.authTokenWrapper = authTokenWrapper;
 		setDaemon(true);
 		setName(HttpGetStatusThread.class.getSimpleName());
 	}
@@ -210,7 +213,7 @@ public class HttpGetStatusThread extends Thread {
 				e.setConnectTimeout(15 * 1000);
 				e.setReadTimeout(15 * 1000);
 				HttpUtil.allowAllCerts(e);
-			});
+			}, authTokenWrapper);
 
 			if (httpResult == null || httpResult.responseCode != 200) {
 				log.logError("Get response failed for " + toGet + ", "

--- a/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/HttpPostOutputQueue.java
+++ b/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/HttpPostOutputQueue.java
@@ -60,11 +60,14 @@ public class HttpPostOutputQueue {
 
 	private final String serverBaseUrl;
 
+	private final AuthTokenWrapper authTokenWrapper;
+
 	/** Wait up to 24 hours for a chunk group to complete, before we drop it. */
 	private static final long CHUNK_GROUP_EXPIRE_TIME_IN_NANOS = TimeUnit.NANOSECONDS.convert(24, TimeUnit.HOURS);
 
-	public HttpPostOutputQueue(String url) {
+	public HttpPostOutputQueue(String url, AuthTokenWrapper authTokenWrapper) {
 		this.serverBaseUrl = url;
+		this.authTokenWrapper = authTokenWrapper;
 
 		for (int x = 0; x < 3; x++) {
 			OutputQueueWorkerThread wt = new OutputQueueWorkerThread();
@@ -286,7 +289,7 @@ public class HttpPostOutputQueue {
 						HttpUtil.allowAllCerts(e);
 						e.setConnectTimeout(10 * 1000);
 						e.setReadTimeout(10 * 1000);
-					});
+					}, authTokenWrapper);
 
 					if (response == null || response.responseCode != 200) {
 						sendFailed = true;

--- a/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/HttpUtil.java
+++ b/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/HttpUtil.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
 
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
@@ -242,6 +244,15 @@ public class HttpUtil {
 					return null;
 				}
 			};
+
+			HostnameVerifier hostnameVerifier = new HostnameVerifier() {
+				@Override
+				public boolean verify(String hostname, SSLSession session) {
+					return true;
+				}
+			};
+
+			huc.setHostnameVerifier(hostnameVerifier);
 
 			// SSL setup
 			SSLContext ctx;

--- a/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/WebSocketManagerThread.java
+++ b/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/WebSocketManagerThread.java
@@ -241,10 +241,12 @@ public class WebSocketManagerThread extends Thread {
 			try {
 				log.logInfo("Attempting to establish connection to web socket, attempt #" + attemptNumber);
 
-				JettyClientEndpoint clientEndpoint = new JettyClientEndpoint(this, wsUrl);
+				String url = wsUrl + "/websockets/file-changes/v1";
+
+				JettyClientEndpoint clientEndpoint = new JettyClientEndpoint(this, url);
 				ClientUpgradeRequest request = new ClientUpgradeRequest();
-				Future<Session> session = wsClient.connect(clientEndpoint,
-						new URI(wsUrl + "/websockets/file-changes/v1"), request);
+
+				Future<Session> session = wsClient.connect(clientEndpoint, new URI(url), request);
 
 				try {
 					Session sess = session.get(CONNECTION_WAIT_TIME_IN_SECONDS, TimeUnit.SECONDS);

--- a/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/WebSocketManagerThread.java
+++ b/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/WebSocketManagerThread.java
@@ -68,6 +68,8 @@ public class WebSocketManagerThread extends Thread {
 
 	private final WebSocketClient wsClient;
 
+	private final AuthTokenWrapper authTokenWrapper;
+
 	/**
 	 * Synchronize on this before accessing. This will only ever contain 0 or 1
 	 * items.
@@ -80,6 +82,8 @@ public class WebSocketManagerThread extends Thread {
 		this.endpoint = new JettyClientEndpoint(this, wsUrl);
 		this.wsUrl = wsUrl;
 		this.watcher = watcher;
+
+		this.authTokenWrapper = watcher.internal_getAuthTokenWrapper();
 
 		// Trust all TLS/SSL certificates and allow large messages
 		SslContextFactory.Client ssl = new SslContextFactory.Client();
@@ -245,6 +249,20 @@ public class WebSocketManagerThread extends Thread {
 				try {
 					Session sess = session.get(CONNECTION_WAIT_TIME_IN_SECONDS, TimeUnit.SECONDS);
 					success = sess.isOpen();
+
+					// TODO: We need to send a message in both the auth and non-auth case, to make
+					// the server implementation easier. See issue for details.
+
+					// TODO: Re-enable this once FW WebSocket has authentication
+					// (https://github.com/eclipse/codewind/issues/1342)
+//					FWAuthToken token = authTokenWrapper.getLatestToken().orElse(null);
+//					if (token != null) {
+//
+//						JSONObject obj = new JSONObject();
+//						obj.put("token", token.getAccessToken());
+//						sess.getRemote().sendString(obj.toString());
+//					}
+
 				} catch (Exception e) {
 
 					String msg = "Unable to connect to web socket: " + e.getClass().getSimpleName() + " (attempt #"

--- a/dev/org.eclipse.codewind.filewatchers.eclipse/src/org/eclipse/codewind/filewatchers/eclipse/CodewindFilewatcherdConnection.java
+++ b/dev/org.eclipse.codewind.filewatchers.eclipse/src/org/eclipse/codewind/filewatchers/eclipse/CodewindFilewatcherdConnection.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import org.eclipse.codewind.filewatchers.JavaNioWatchService;
 import org.eclipse.codewind.filewatchers.core.FWLogger;
 import org.eclipse.codewind.filewatchers.core.Filewatcher;
+import org.eclipse.codewind.filewatchers.core.IAuthTokenProvider;
 import org.eclipse.codewind.filewatchers.core.WatchEventEntry;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
@@ -50,15 +51,16 @@ public class CodewindFilewatcherdConnection {
 
 	private final String clientUuid;
 
-	public CodewindFilewatcherdConnection(String baseHttpUrl, File pathToCwctl, ICodewindProjectTranslator translator) {
+	public CodewindFilewatcherdConnection(String baseHttpUrl, File pathToCwctl, ICodewindProjectTranslator translator,
+			IAuthTokenProvider authTokenProvider /* nullable */) {
 
-		if(pathToCwctl == null) {
-			throw new RuntimeException("A valid path to the Codewind CLI is required: "+pathToCwctl);
+		if (pathToCwctl == null) {
+			throw new RuntimeException("A valid path to the Codewind CLI is required: " + pathToCwctl);
 		}
-		
+
 		if (!pathToCwctl.exists() || !pathToCwctl.canExecute()) {
-			throw new RuntimeException(
-					this.getClass().getSimpleName() + " was passed an invalid installer path: " + pathToCwctl.getPath());
+			throw new RuntimeException(this.getClass().getSimpleName() + " was passed an invalid installer path: "
+					+ pathToCwctl.getPath());
 		}
 
 		this.clientUuid = UUID.randomUUID().toString();
@@ -87,7 +89,7 @@ public class CodewindFilewatcherdConnection {
 		// outside the workspace (eg the standalone Codewind settings directory).
 		this.platformWatchService = new EclipseResourceWatchService();
 		this.fileWatcher = new Filewatcher(url, clientUuid, platformWatchService, new JavaNioWatchService(),
-				pathToCwctl.getPath());
+				pathToCwctl.getPath(), authTokenProvider);
 
 		this.baseHttpUrl = url;
 

--- a/dev/org.eclipse.codewind.filewatchers.standalonenio/src/org/eclipse/codewind/filewatchers/Main.java
+++ b/dev/org.eclipse.codewind.filewatchers.standalonenio/src/org/eclipse/codewind/filewatchers/Main.java
@@ -16,9 +16,11 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.UUID;
 
+import org.eclipse.codewind.filewatchers.core.FWAuthToken;
 import org.eclipse.codewind.filewatchers.core.FWLogger;
 import org.eclipse.codewind.filewatchers.core.Filewatcher;
 import org.eclipse.codewind.filewatchers.core.FilewatcherUtils;
+import org.eclipse.codewind.filewatchers.core.IAuthTokenProvider;
 import org.eclipse.codewind.filewatchers.core.IPlatformWatchService;
 
 public class Main {
@@ -53,7 +55,8 @@ public class Main {
 
 		String pathToCli = System.getenv("MOCK_CWCTL_INSTALLER_PATH");
 
-		Filewatcher fw = new Filewatcher(url, UUID.randomUUID().toString(), platformWatchService, null, pathToCli);
+		Filewatcher fw = new Filewatcher(url, UUID.randomUUID().toString(), platformWatchService, null, pathToCli,
+				null);
 
 		while (true) {
 			FilewatcherUtils.sleepIgnoreInterrupt(1000);


### PR DESCRIPTION
Parent issue: https://github.com/eclipse/codewind/issues/1309