### PR TITLE
CW Issue #1348: Pass JSONObject directly for socket authentication

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindSocket.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindSocket.java
@@ -106,7 +106,7 @@ public class CodewindSocket {
 					try {
 						JSONObject obj = new JSONObject();
 						obj.put("token", authToken.getToken());
-						socket.emit("authentication", obj.toString());
+						socket.emit("authentication", obj);
 					} catch (Exception e) {
 						Logger.logError("An error occurred trying to pass the authentication token to the socket", e);
 						return;


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/1348

Pass the JSONObject directly to the socket for authentication instead of converting to a String.