### PR TITLE
CW Issue #1392: Prompt for push registry on drag drop if needed

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectType.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectType.java
@@ -88,6 +88,10 @@ public class ProjectType {
 		return extension != null;
 	}
 	
+	public static boolean isCodewindStyle(String typeId) {
+		return !"appsodyExtension".equals(typeId) && !"odo".equals(typeId);
+	}
+	
 	public static String getDisplayName(String typeId) {
 		if (typeId == null) {
 			return Messages.GenericUnknown;
@@ -113,5 +117,5 @@ public class ProjectType {
 			default:
 				return null;
 		}
-	}
+	} 
 }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -128,7 +128,7 @@ BindProjectAlreadyExistsError=A Codewind project with the name {0} already exist
 BindProjectWizardTitle=Add Existing Project to Codewind
 BindProjectWizardRemoveTask=Removing existing deployments
 BindProjectWizardDisableTask=Disabling existing deployments
-BindProjectWizardJobLabel=Adding project to Codewind: {0}
+BindProjectWizardJobLabel=Adding project to {0}: {1}
 BindProjectWizardError=An error occurred trying to add the {0} project to Codewind.
 
 ProjectDeployedDialogShell=Manage Deployments

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorDropAssistant.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorDropAssistant.java
@@ -11,22 +11,29 @@
 
 package org.eclipse.codewind.ui.internal.views;
 
+import org.eclipse.codewind.core.CodewindCorePlugin;
 import org.eclipse.codewind.core.internal.CodewindApplication;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.cli.ProjectUtil;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
+import org.eclipse.codewind.core.internal.constants.ProjectType;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
+import org.eclipse.codewind.ui.internal.actions.OpenAppOverviewAction;
 import org.eclipse.codewind.ui.internal.messages.Messages;
+import org.eclipse.codewind.ui.internal.prefs.RegistryManagementDialog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.util.LocalSelectionTransfer;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.dnd.DropTargetEvent;
 import org.eclipse.swt.dnd.TransferData;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.navigator.CommonDropAdapter;
 import org.eclipse.ui.navigator.CommonDropAdapterAssistant;
 
@@ -90,12 +97,47 @@ public class CodewindNavigatorDropAssistant extends CommonDropAdapterAssistant {
 		job.schedule();
 		
 		// Add the application to the target connection
-		job = new Job(NLS.bind(Messages.BindProjectWizardJobLabel, sourceApp.name)) {
+		String jobName = NLS.bind(Messages.BindProjectWizardJobLabel, new String[] {targetConn.getName(), sourceApp.name});
+		job = new Job(jobName) {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
-					ProjectUtil.bindProject(sourceApp.name, sourceApp.fullLocalPath.toOSString(), sourceApp.projectLanguage.getId(), sourceApp.projectType.getId(), targetConn.getConid(), monitor);
+					SubMonitor mon = SubMonitor.convert(monitor, jobName, 100);
+					if (!targetConn.isLocal() && ProjectType.isCodewindStyle(sourceApp.projectType.getId())) {
+						try {
+							if (!targetConn.requestHasPushRegistry()) {
+								Display.getDefault().syncExec(new Runnable() {
+									@Override
+									public void run() {
+										if (MessageDialog.openQuestion(getShell(), Messages.NoPushRegistryTitle, Messages.NoPushRegistryMessage)) {
+											RegistryManagementDialog.open(getShell(), targetConn, mon.split(40));
+										}
+									}
+								});
+							}
+						} catch (Exception e) {
+							Logger.logError("An error occurred while setting up the registry dialog", e); //$NON-NLS-1$
+						}
+					}
+					if (mon.isCanceled()) {
+						return Status.CANCEL_STATUS;
+					}
+					mon.setWorkRemaining(60);
+					ProjectUtil.bindProject(sourceApp.name, sourceApp.fullLocalPath.toOSString(), sourceApp.projectLanguage.getId(), sourceApp.projectType.getId(), targetConn.getConid(), mon.split(60));
+					if (mon.isCanceled()) {
+						return Status.CANCEL_STATUS;
+					}
 					targetConn.refreshApps(null);
+					CodewindApplication newApp = targetConn.getAppByName(sourceApp.name);
+					if (newApp != null) {
+						if (CodewindCorePlugin.getDefault().getPreferenceStore().getBoolean(CodewindCorePlugin.AUTO_OPEN_OVERVIEW_PAGE)) {
+							Display.getDefault().asyncExec(() -> OpenAppOverviewAction.openAppOverview(newApp));
+						}
+					} else {
+						Logger.logError("The " + sourceApp.name + " application could not be found on connection: " + targetConn.getName()); //$NON-NLS-1$ //$NON-NLS-2$
+					}
+					ViewHelper.refreshCodewindExplorerView(targetConn);
+					ViewHelper.expandConnection(targetConn);
 				} catch (Exception e) {
 					Logger.logError("An error occured trying to add the project to Codewind: " + sourceApp.fullLocalPath.toOSString(), e); //$NON-NLS-1$
 					return new Status(IStatus.ERROR, CodewindUIPlugin.PLUGIN_ID, NLS.bind(Messages.BindProjectWizardError, sourceApp.fullLocalPath.toOSString()), e);

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/BindProjectWizard.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/BindProjectWizard.java
@@ -23,6 +23,7 @@ import org.eclipse.codewind.core.internal.connection.CodewindConnectionManager;
 import org.eclipse.codewind.core.internal.connection.ProjectTypeInfo;
 import org.eclipse.codewind.core.internal.connection.ProjectTypeInfo.ProjectSubtypeInfo;
 import org.eclipse.codewind.core.internal.constants.ProjectInfo;
+import org.eclipse.codewind.core.internal.constants.ProjectType;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.actions.ImportProjectAction;
 import org.eclipse.codewind.ui.internal.actions.OpenAppOverviewAction;
@@ -147,12 +148,12 @@ public class BindProjectWizard extends Wizard implements INewWizard {
 		final ProjectSubtypeInfo projectSubtype = projectTypePage.getSubtype();
 		final String language = projectTypePage.getLanguage();		
 		
-		Job job = new Job(NLS.bind(Messages.BindProjectWizardJobLabel, name)) {
+		Job job = new Job(NLS.bind(Messages.BindProjectWizardJobLabel, new String[] {connection.getName(), name})) {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
 					SubMonitor mon = SubMonitor.convert(monitor, 140);
-					if (!connection.isLocal() && !type.getId().equals("appsodyExtension") && !type.getId().equals("odo")) {
+					if (!connection.isLocal() && ProjectType.isCodewindStyle(type.getId())) {
 						try {
 							if (!connection.requestHasPushRegistry()) {
 								Display.getDefault().syncExec(new Runnable() {
@@ -167,6 +168,9 @@ public class BindProjectWizard extends Wizard implements INewWizard {
 						} catch (Exception e) {
 							Logger.logError("An error occurred while setting up the registry dialog", e); //$NON-NLS-1$
 						}
+					}
+					if (mon.isCanceled()) {
+						return Status.CANCEL_STATUS;
 					}
 					mon.setWorkRemaining(100);
 					if (selectedBehaviour != null) {


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/1392

When dragging and dropping a Codewind style project on to a remote connection that does not have a push registry defined a dialog should pop up to prompt the user to add one, just as it does when the user creates a project or adds an existing project.

Also, when dragging and dropping a project onto a connection, the project overview page should be opened as this is now a new project for that connection.