### PR TITLE
CW Issue #1405: Force the user to either create a push registry or cancel project creation

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -172,6 +172,9 @@ public class Messages extends NLS {
 	public static String BindProjectWizardJobLabel;
 	public static String BindProjectWizardError;
 	
+	public static String MoveProjectJobLabel;
+	public static String MoveProjectError;
+	
 	public static String ProjectDeployedDialogShell;
 	public static String ProjectDeployedDialogTitle;
 	public static String ProjectDeployedDialogMessage;
@@ -357,6 +360,7 @@ public class Messages extends NLS {
 	public static String ManageRegistriesLinkTooltipLocal;
 	public static String NoPushRegistryTitle;
 	public static String NoPushRegistryMessage;
+	public static String NoPushRegistryError;
 	
 	public static String AppOverviewEditorCreateError;
 	public static String AppOverviewEditorPartName;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -131,6 +131,9 @@ BindProjectWizardDisableTask=Disabling existing deployments
 BindProjectWizardJobLabel=Adding project to {0}: {1}
 BindProjectWizardError=An error occurred trying to add the {0} project to Codewind.
 
+MoveProjectJobLabel=Moving project to {0}: {1}
+MoveProjectError=An error occurred while moving the {0} project from {1} to {2}.
+
 ProjectDeployedDialogShell=Manage Deployments
 ProjectDeployedDialogTitle=Project Already Deployed
 ProjectDeployedDialogMessage=The {0} project is already deployed and enabled on other connections. It is not recommended to have the same project on multiple connections.
@@ -350,7 +353,8 @@ ManageRegistriesLinkText=Manage Container Registries...
 ManageRegistriesLinkTooltip=Add any pull registries required by your project. Add a push registry for Codewind style projects.
 ManageRegistriesLinkTooltipLocal=Add any pull registries required by your project.
 NoPushRegistryTitle=Push Registry Required
-NoPushRegistryMessage=Codewind style projects require a push registry. Do you want to set one up now?
+NoPushRegistryMessage=Codewind style projects require a push registry. Select OK to set one up or Cancel to cancel the current operation.
+NoPushRegistryError=The operation could not complete because no push registry was created.
 
 AppOverviewEditorCreateError=The application overview editor could not be created for the input: {0}. Check the logs for more details.
 AppOverviewEditorPartName=Application Overview: {0} ({1})


### PR DESCRIPTION
For Codewind style projects on remote connections if there is no push registry, force the user to create one or cancel creation/bind.