### PR TITLE
CW Issue #1386: Show an error if authentication fails for the socket connection

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindSocket.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindSocket.java
@@ -135,6 +135,10 @@ public class CodewindSocket {
 			@Override
 			public void call(Object... arg0) {
 				Logger.logError("SocketIO authentication failed: " + arg0[0]);
+				// Completely disconnect in this case
+				connection.disconnect();
+				CoreUtil.updateConnection(connection);
+				CoreUtil.openDialog(true, Messages.Connection_ErrConnection_AuthFailedTitle, NLS.bind(Messages.Connection_ErrConnection_AuthFailed, connection.getName()));
 			}
 		})
 		.on(Socket.EVENT_CONNECT_ERROR, new Emitter.Listener() {

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
@@ -37,6 +37,8 @@ public class Messages extends NLS {
 	public static String Connection_ErrGettingProjectListTitle;
 	public static String Connection_ErrConnection_UpdateCacheException;
 	public static String Connection_ErrConnection_CodewindNotReady;
+	public static String Connection_ErrConnection_AuthFailedTitle;
+	public static String Connection_ErrConnection_AuthFailed;
 
 	public static String ConnectionException_ConnectingToMCFailed;
 

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
@@ -30,6 +30,8 @@ Connection_ErrContactingServerDialogTitle=Error contacting Codewind server
 Connection_ErrGettingProjectListTitle=Error getting list of projects
 Connection_ErrConnection_UpdateCacheException=An error occurred while initializing the Codewind connection. Check the workspace logs.
 Connection_ErrConnection_CodewindNotReady=Codewind failed to go into the ready state. Try stopping and re-starting Codewind.
+Connection_ErrConnection_AuthFailedTitle=Authorization Error
+Connection_ErrConnection_AuthFailed=Authorization failed for the {0} connection. Check the workspace log for more information. To change your username or password, right-click on the connection and select Edit.
 
 ConnectionException_ConnectingToMCFailed=Connecting to Codewind at {0} failed.
 


### PR DESCRIPTION
Show an error to the user if authentication fails for the socket connection.