### PR TITLE
Choose performance- / application-container dash based on availabilit…

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.eclipse.codewind.core.internal.HttpUtil.HttpResult;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
 import org.eclipse.codewind.core.internal.console.ProjectLogInfo;
 import org.eclipse.codewind.core.internal.constants.AppStatus;
@@ -28,7 +29,6 @@ import org.eclipse.codewind.core.internal.constants.ProjectCapabilities;
 import org.eclipse.codewind.core.internal.constants.ProjectLanguage;
 import org.eclipse.codewind.core.internal.constants.ProjectType;
 import org.eclipse.codewind.core.internal.constants.StartMode;
-import org.eclipse.codewind.core.internal.HttpUtil.HttpResult;
 import org.eclipse.core.runtime.IPath;
 import org.json.JSONObject;
 
@@ -260,7 +260,11 @@ public class CodewindApplication {
 	
 	public URL getMetricsUrl() {
 		try {
-			return new URL(getBaseUrl(), projectLanguage.getMetricsRoot());
+			if ((!this.injectMetrics) && this.metricsAvailable) {
+				return new URL(getBaseUrl(), projectLanguage.getMetricsRoot());
+			} else {
+				return (connection.getBaseURI().resolve(CoreConstants.PERF_METRICS_DASH + "/" + projectLanguage.getId() + "?theme=dark&projectID=" + projectID)).toURL();
+			}
 		} catch (MalformedURLException e) {
 			Logger.logError("An error occurred trying to construct the application metrics URL", e);
 		}

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/CoreConstants.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/CoreConstants.java
@@ -162,7 +162,8 @@ public class CoreConstants {
 			QUERY_VIEW = "view",
 			VIEW_MONITOR = "monitor",
 			VIEW_OVERVIEW = "overview",
-			PERF_MONITOR = "performance/charts"
+			PERF_MONITOR = "performance/charts",
+			PERF_METRICS_DASH = "performance/monitor/dashboard"
 
 			;
 }


### PR DESCRIPTION
…y of injected / provided metrics

Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

This PR alters the return value of getMetricsUrl() to provide the performance-container dashboard link, unless we have not injected metrics and there is a dashboard in the application container, in which case the original application-container dashboard link is returned.