### PR TITLE
CW Issue #1479: Remove radio buttons from registry table

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/UIConstants.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/UIConstants.java
@@ -19,6 +19,6 @@ public class UIConstants {
 	public static final String 
 		DOC_BASE_URL = "https://www.eclipse.org/codewind",
 		CWSETTINGS_INFO_URL = DOC_BASE_URL + "/mdteclipsemanagingprojects.html",
-		TEMPLATES_INFO_URL = DOC_BASE_URL + "/mdteclipseworkingwithtemplates.html";
-
+		TEMPLATES_INFO_URL = DOC_BASE_URL + "/mdteclipseworkingwithtemplates.html",
+		REGISTRY_INFO_URL = DOC_BASE_URL + "/dockerregistry.html";
 }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -463,11 +463,14 @@ public class Messages extends NLS {
 	public static String RegMgmtLocalDescription;
 	public static String RegMgmtLearnMoreLink;
 	public static String RegMgmtAddButton;
+	public static String RegMgmtSetPushButton;
 	public static String RegMgmtRemoveButton;
 	public static String RegMgmtAddressColumn;
 	public static String RegMgmtUsernameColumn;
 	public static String RegMgmtNamespaceColumn;
 	public static String RegMgmtPushRegColumn;
+	public static String RegMgmtPushRegTrue;
+	public static String RegMgmtPushRegFalse;
 	
 	public static String RegMgmtAddDialogShell;
 	public static String RegMgmtAddDialogTitle;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -447,25 +447,28 @@ EditConnectionDialogTitle=Edit a connection
 EditConnectionDialogMessage=Modify the {0} connection. The password field must be filled in to authorize the changes even if the password does not need to be updated.
 UpdateConnectionJobLabel=Updating connection: {0}
 
-RegMgmtActionLabel=Mana&ge Container Registries...
+RegMgmtActionLabel=Mana&ge Image Registries...
 
-RegMgmtDialogTitle=Manage Container Registries
-RegMgmtDialogMessage=Add and remove container registries. Designate a push registry.
-RegMgmtDialogLocalMessage=Add and remove container registries.
+RegMgmtDialogTitle=Manage Image Registries
+RegMgmtDialogMessage=Add and remove image registries. Designate a push registry.
+RegMgmtDialogLocalMessage=Add and remove image registries.
 
-RegMgmtDescription=Provide registries for projects that need to pull content in order to build. A single registry can be designated as a push registry.
+RegMgmtDescription=Provide registries for projects that need to pull content in order to build. A single push registry is required for Codewind style projects.
 RegMgmtLocalDescription=Provide registries for projects that need to pull content in order to build.
 RegMgmtLearnMoreLink=Learn more...
 RegMgmtAddButton=&Add...
+RegMgmtSetPushButton=Set &Push
 RegMgmtRemoveButton=&Remove
 RegMgmtAddressColumn=Address
 RegMgmtUsernameColumn=User Name
 RegMgmtNamespaceColumn=Namespace
 RegMgmtPushRegColumn=Push Registry
+RegMgmtPushRegTrue=True
+RegMgmtPushRegFalse=False
 
-RegMgmtAddDialogShell=Container Registries
-RegMgmtAddDialogTitle=Add Container Registry
-RegMgmtAddDialogMessage=Fill in the details for the new container registry.
+RegMgmtAddDialogShell=Image Registries
+RegMgmtAddDialogTitle=Add Image Registry
+RegMgmtAddDialogMessage=Fill in the details for the new image registry.
 RegMgmtAddDialogAddressLabel=Address:
 RegMgmtAddDialogUsernameLabel=User name:
 RegMgmtAddDialogPasswordLabel=Password:
@@ -476,13 +479,13 @@ RegMgmtAddDialogAddressInUse=The address is already used by an existing registry
 RegMgmtAddDialogNoUsername=Fill in the user name
 RegMgmtAddDialogNoPassword=Fill in the password
 RegMgmtAddDialogNoNamespace=The namespace must be filled in for a push registry
-RegMgmtUpdateError=One or more container registry updates failed.
+RegMgmtUpdateError=One or more image registry updates failed.
 RegMgmtRemoveFailed=An error occurred trying to remove registry: {0}
 RegMgmtUpdateFailed=An error occurred trying to update registry: {0}
 RegMgmtAddFailed=An error occurred trying to add registry: {0}
 RegMgmtSetPushRegFailed=An error occurred trying to set the push registry: {0}
 
-RegMgmtNamespaceDialogShell=Container Registries
+RegMgmtNamespaceDialogShell=Image Registries
 RegMgmtNamespaceDialogTitle=Push Registry Namespace
 RegMgmtNamespaceDialogMessage=Provide a namespace for the push registry.
 


### PR DESCRIPTION
- Radio buttons in a table are not accessible so use text instead and add a Set Push button with the other buttons (Add, Remove)
- Changed the name to be Manage Image Registries instead of Manage Container Registries
- Set the learn more link to be https://www.eclipse.org/codewind/dockerregistry.html
- Fixed a bug where if a registry was removed and the user added it back again and did a save it would treat that as a change when it is not