### PR TITLE
CW Issue #1387: Use the new cloud connection icon for the context menu

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/CodewindUIPlugin.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/CodewindUIPlugin.java
@@ -50,6 +50,7 @@ public class CodewindUIPlugin extends AbstractUIPlugin {
 			LAUNCH_DEBUG_ICON = "elcl16/debug_exc.png",
 			LAUNCH_RUN_ICON = "elcl16/run_exc.png",
 			REFRESH_ICON = "elcl16/refresh.png",
+			NEW_CLOUD_ICON = "elcl16/new_cloud.png",
 			GENERIC_ICON = "obj16/generic.png",
 			GO_ICON = "obj16/go.png",
 			JAVA_ICON = "obj16/java.png",
@@ -130,6 +131,7 @@ public class CodewindUIPlugin extends AbstractUIPlugin {
         registerImage(registry, LAUNCH_DEBUG_ICON, ICON_BASE_URL + LAUNCH_DEBUG_ICON);
         registerImage(registry, LAUNCH_RUN_ICON, ICON_BASE_URL + LAUNCH_RUN_ICON);
         registerImage(registry, REFRESH_ICON, ICON_BASE_URL + REFRESH_ICON);
+        registerImage(registry, NEW_CLOUD_ICON, ICON_BASE_URL + NEW_CLOUD_ICON);
         registerImage(registry, GENERIC_ICON, ICON_BASE_URL + GENERIC_ICON);
         registerImage(registry, GO_ICON, ICON_BASE_URL + GO_ICON);
         registerImage(registry, JAVA_ICON, ICON_BASE_URL + JAVA_ICON);

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/AddConnectionAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/AddConnectionAction.java
@@ -28,7 +28,7 @@ public class AddConnectionAction extends SelectionProviderAction {
 
 	public AddConnectionAction(ISelectionProvider selectionProvider) {
 		super(selectionProvider, "New Connection");
-		setImageDescriptor(CodewindUIPlugin.getDefaultIcon());
+		setImageDescriptor(CodewindUIPlugin.getImageDescriptor(CodewindUIPlugin.NEW_CLOUD_ICON));
 		selectionChanged(getStructuredSelection());
 	}
 

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/EditConnectionAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/EditConnectionAction.java
@@ -13,7 +13,6 @@ package org.eclipse.codewind.ui.internal.actions;
 
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
-import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.codewind.ui.internal.wizards.EditConnectionDialog;
 import org.eclipse.jface.viewers.ISelectionProvider;
@@ -30,7 +29,6 @@ public class EditConnectionAction extends SelectionProviderAction {
 
 	public EditConnectionAction(ISelectionProvider selectionProvider) {
 		super(selectionProvider, Messages.EditConnectionActionLabel);
-		setImageDescriptor(CodewindUIPlugin.getDefaultIcon());
 		selectionChanged(getStructuredSelection());
 	}
 

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RemoveConnectionAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RemoveConnectionAction.java
@@ -14,7 +14,6 @@ package org.eclipse.codewind.ui.internal.actions;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
 import org.eclipse.codewind.core.internal.connection.CodewindConnectionManager;
-import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -29,7 +28,6 @@ public class RemoveConnectionAction extends SelectionProviderAction {
 
 	public RemoveConnectionAction(ISelectionProvider selectionProvider) {
 		super(selectionProvider, Messages.RemoveConnectionActionLabel);
-		setImageDescriptor(CodewindUIPlugin.getDefaultIcon());
 		selectionChanged(getStructuredSelection());
 	}
 


### PR DESCRIPTION
- Use the new cloud connection icon for the new connection context menu item
- Remove the Codewind icon for some menu items (on a cloud connection almost all menu items had this icon)
