### PR TITLE
Fix: show open app monitor in more cases

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/OpenAppMonitorAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/OpenAppMonitorAction.java
@@ -75,11 +75,6 @@ public class OpenAppMonitorAction extends SelectionProviderAction {
 			return;
 		}
 		
-        app.confirmMetricsAvailable();
-        if (!app.getMetricsAvailable()) {
-        	CoreUtil.openDialog(true, Messages.GenericActionNotSupported, Messages.AppMonitorNotSupported);
-        	return;
-        }
 
 		try {
 			IWebBrowser browser = null;
@@ -106,6 +101,6 @@ public class OpenAppMonitorAction extends SelectionProviderAction {
     }
     
     public boolean showAction() {
-    	return app != null && app.getMetricsAvailable() && app.projectLanguage.getMetricsRoot() != null;
+    	return app != null && app.projectLanguage.getMetricsRoot() != null;
     }
 }


### PR DESCRIPTION
This means we will show the `open app monitor` button on more types of projects, specifically java projects that are not microprofile or spring (e.g. Open Liberty, which is type `docker`). 

We will show the button even if the projects are not hosting their own dashboard (e.g. on `http://localhost/31200/javametrics-dash). In those cases, the `open app monitor` button will open the new app monitor dashboard hosted on our performance container