### PR TITLE
Issue #236: Check notify flag on appDetailStatus and notify user if true

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplicationFactory.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplicationFactory.java
@@ -21,7 +21,9 @@ import org.eclipse.codewind.core.internal.constants.CoreConstants;
 import org.eclipse.codewind.core.internal.constants.ProjectLanguage;
 import org.eclipse.codewind.core.internal.constants.ProjectType;
 import org.eclipse.codewind.core.internal.constants.StartMode;
+import org.eclipse.codewind.core.internal.messages.Messages;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.osgi.util.NLS;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -164,6 +166,19 @@ public class CodewindApplicationFactory {
 					JSONObject detailObj = appJso.getJSONObject(CoreConstants.KEY_DETAILED_APP_STATUS);
 					if (detailObj != null && detailObj.has(CoreConstants.KEY_MESSAGE)) {
 						detail = detailObj.getString(CoreConstants.KEY_MESSAGE);
+						if (detailObj.has(CoreConstants.KEY_NOTIFY) && detailObj.getBoolean(CoreConstants.KEY_NOTIFY)) {
+							// Need to notify the user of the problem
+							CoreUtil.DialogType type = CoreUtil.DialogType.ERROR;
+							if (detailObj.has(CoreConstants.KEY_SEVERITY)) {
+								String severity = detailObj.getString(CoreConstants.KEY_SEVERITY);
+								if (CoreConstants.VALUE_WARN.equals(severity)) {
+									type = CoreUtil.DialogType.WARN;
+								} else if (CoreConstants.VALUE_INFO.equals(severity)) {
+									type = CoreUtil.DialogType.INFO;
+								}
+							}
+							CoreUtil.openDialog(type, NLS.bind(Messages.ProjectErrorTitle, app.name), detail);
+						}
 					}
 				}
 				app.setAppStatus(appStatus, detail);

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CoreUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CoreUtil.java
@@ -31,12 +31,32 @@ public class CoreUtil {
 	
 	// Provide a way for users to override the path used for running commands
 	private static final String ENV_PATH_PROPERTY = "org.eclipse.codewind.envPath";
+	
+	public enum DialogType {
+		ERROR(MessageDialog.ERROR),
+		WARN(MessageDialog.WARNING),
+		INFO(MessageDialog.INFORMATION);
+		
+		private int value;
+
+		private DialogType(int value) {
+			this.value = value;
+		}
+		
+		public int getValue() {
+			return value;
+		}
+	};
 
 	/**
 	 * Open a dialog on top of the current active window. Can be called off the UI thread.
 	 */
 	public static void openDialog(boolean isError, String title, String msg) {
-		final int kind = isError ? MessageDialog.ERROR : MessageDialog.INFORMATION;
+		openDialog(isError ? DialogType.ERROR : DialogType.INFO, title, msg);
+	}
+	
+	public static void openDialog(DialogType type, String title, String msg) {
+		final int kind = type.getValue();
 
 		Display.getDefault().asyncExec(new Runnable() {
 			@Override

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/CoreConstants.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/CoreConstants.java
@@ -79,6 +79,7 @@ public class CoreConstants {
 			KEY_APP_STATUS = "appStatus",
 			KEY_DETAILED_APP_STATUS = "detailedAppStatus",
 			KEY_MESSAGE = "message",
+			KEY_NOTIFY = "notify",
 			KEY_BUILD_STATUS = "buildStatus",
 			KEY_DETAILED_BUILD_STATUS = "detailedBuildStatus",
 			KEY_LAST_BUILD = "lastbuild",
@@ -91,6 +92,10 @@ public class CoreConstants {
 			KEY_AUTO_BUILD = "autoBuild",
 			KEY_APP_BASE_URL = "appBaseURL",
 			KEY_INJECT_METRICS = "enable",
+			
+			VALUE_INFO = "INFO",
+			VALUE_WARN = "WARN",
+			VALUE_ERROR = "ERROR",
 
 			KEY_LANGUAGE = "language",
 			KEY_FRAMEWORK = "framework",

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
@@ -104,6 +104,8 @@ public class Messages extends NLS {
 	
 	public static String UpgradeResultMigrated;
 	public static String UpgradeResultNotMigrated;
+	
+	public static String ProjectErrorTitle;
 
 	static {
 		// initialize resource bundle

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
@@ -97,3 +97,5 @@ ProcessHelperUnknownError=Unknown error
 
 UpgradeResultMigrated=The following projects were successfully migrated:
 UpgradeResultNotMigrated=Problems were encountered migrating these projects. Try manually adding them as existing projects to Codewind:
+
+ProjectErrorTitle=An problem occurred with the {0} project


### PR DESCRIPTION
Fixes #236

Check the notify flag in the appDetailStatus object and notify the user if true. It pops up a dialog for now but in the future (see https://github.com/eclipse/codewind/issues/655) it could show something like:
```
project1 [Starting][Build successful](Error/Warning hover for details)
```
Though I did notice that the messages are rather long.