### PR TITLE
CW Issue #1661: Update versions for the 0.8.0 release

### DIFF
--- a/dev/ant_build/build-cw.xml
+++ b/dev/ant_build/build-cw.xml
@@ -10,7 +10,7 @@
 -->
 
 <project name="cw_build" default="generateOpenCWUpdateSite">
-    <property name="level_tag" value="0.7.0"/>
+    <property name="level_tag" value="0.8.0"/>
     <property name="delegate.build.dir" location="${basedir}/../" />
     <property name="disable.run.executeMetatypeValidation" value="true"/>
     <property name="disable.run.unzipIfixReleaseZip" value="true"/>

--- a/dev/org.eclipse.codewind.base/feature.xml
+++ b/dev/org.eclipse.codewind.base/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.codewind.base"
       label="%featureName"
-      version="1.5.0.qualifier"
+      version="1.5.1.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/dev/org.eclipse.codewind.core/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Codewind Core Plug-in
 Bundle-SymbolicName: org.eclipse.codewind.core;singleton:=true
-Bundle-Version: 1.5.0.qualifier
+Bundle-Version: 1.5.1.qualifier
 Bundle-Activator: org.eclipse.codewind.core.CodewindCorePlugin
 Bundle-Vendor: Eclipse.org
 Bundle-Localization: plugin

--- a/dev/org.eclipse.codewind.filewatchers.core/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.filewatchers.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Codewind Filewatcher Core Plug-in
 Bundle-SymbolicName: org.eclipse.codewind.filewatchers.core;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-ClassPath: .,
  lib/jetty-client-9.4.23.v20191118.jar,

--- a/dev/org.eclipse.codewind.filewatchers.eclipse/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.filewatchers.eclipse/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Codewind Filewatcher Eclipse Plug-in
 Bundle-SymbolicName: org.eclipse.codewind.filewatchers.eclipse;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.codewind.filewatchers.eclipse
 Import-Package: org.eclipse.codewind.filewatchers,

--- a/dev/org.eclipse.codewind.filewatchers.standalonenio/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.filewatchers.standalonenio/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Codewind Filewatcher Standalonenio Plug-in
 Bundle-SymbolicName: org.eclipse.codewind.filewatchers.standalonenio;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1.qualifier
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.codewind.filewatchers
 Import-Package: org.eclipse.codewind.filewatchers.core

--- a/dev/org.eclipse.codewind.test/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Codewind Test Plug-in
 Bundle-SymbolicName: org.eclipse.codewind.test;singleton:=true
-Bundle-Version: 1.4.0.qualifier
+Bundle-Version: 1.4.1.qualifier
 Bundle-Activator: org.eclipse.codewind.test.CodewindTestPlugin
 Bundle-Vendor: Eclipse.org
 Require-Bundle: org.eclipse.core.runtime

--- a/dev/org.eclipse.codewind.ui/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Codewind UI Plug-in
 Bundle-SymbolicName: org.eclipse.codewind.ui;singleton:=true
-Bundle-Version: 1.5.0.qualifier
+Bundle-Version: 1.5.1.qualifier
 Bundle-Activator: org.eclipse.codewind.ui.CodewindUIPlugin
 Bundle-Vendor: Eclipse.org
 Bundle-Localization: plugin

--- a/dev/org.eclipse.codewind/feature.xml
+++ b/dev/org.eclipse.codewind/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.codewind"
       label="%featureName"
-      version="0.7.0.qualifier"
+      version="0.8.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.codewind.core">
 


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/1661

Update the versions for the 0.8.0 release.  Updated the third digit since there are only bug fixes going in to this release.