### PR TITLE
Update the CLI install location to default install version

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/CodewindCorePlugin.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/CodewindCorePlugin.java
@@ -35,8 +35,6 @@ public class CodewindCorePlugin extends AbstractUIPlugin {
 	// The plug-in ID
 	public static final String PLUGIN_ID = "org.eclipse.codewind.core"; //$NON-NLS-1$
 	
-	public static final String FEATURE_VERSION = "0.7.0"; //$NON-NLS-1$
-	
 	public static final String DEFAULT_ICON_PATH = "icons/codewind.png"; //$NON-NLS-1$
 	
 	public static final String CW_INSTALL_TIMEOUT = "cwInstallTimeout";

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/CLIUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/CLIUtil.java
@@ -182,7 +182,7 @@ public class CLIUtil {
 	private static String getCLIInstallDir() {
 		IPath userHome = CoreUtil.getUserHome();
 		if (userHome != null) {
-			return userHome.append(CODEWIND_STORE_DIR).append(CodewindCorePlugin.FEATURE_VERSION).toOSString();
+			return userHome.append(CODEWIND_STORE_DIR).append(InstallUtil.DEFAULT_INSTALL_VERSION).toOSString();
 		}
 		IPath stateLoc = CodewindCorePlugin.getDefault().getStateLocation();
 		return stateLoc.append(INSTALLER_DIR).toOSString();


### PR DESCRIPTION
Update the CLI install location to match the feature version. Need to remember to do this when updating the feature version next time. Looked into doing this automatically but though it is easy to get the version for a plugin, it is not so easy to get the version for a feature. I tried this but it did not work: http://vladdu.blogspot.com/2010/06/retrieving-features-version-number-in.html. It could be a self-hosting thing but then we want it to work when self-hosting.