### PR TITLE
CW Issue #1722: Fix NPE in NewCodewindProjectWizard - need to check for null connection

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectWizard.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectWizard.java
@@ -68,7 +68,7 @@ public class NewCodewindProjectWizard extends Wizard implements INewWizard {
 
 	@Override
 	public void addPages() {
-		if (connection.isLocal()) {
+		if (connection == null || connection.isLocal()) {
 			if (CodewindManager.getManager().getInstallerStatus() != null) {
 				// The installer is currently running
 				CodewindInstall.installerActiveDialog(CodewindManager.getManager().getInstallerStatus());
@@ -139,7 +139,7 @@ public class NewCodewindProjectWizard extends Wizard implements INewWizard {
 					SubMonitor mon = SubMonitor.convert(monitor, 140);
 					
 					// Check for a push registry if Codewind style project
-					if (!connection.isLocal() && info.isCodewindStyle() && !connection.requestHasPushRegistry()) {
+					if (!newConnection.isLocal() && info.isCodewindStyle() && !newConnection.requestHasPushRegistry()) {
 						Display.getDefault().syncExec(new Runnable() {
 							@Override
 							public void run() {


### PR DESCRIPTION
The connection is null if the global new codewind project menu item is invoked so need to check for null. If the connection is null then treat as a local connection (until support is added for choosing a connection). Checked other calls to isLocal method in the code and they are ok.