### PR TITLE
CW Issue #1731: Fix label for node debug web browser dialog

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/debug/WebBrowserSelectionDialog.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/debug/WebBrowserSelectionDialog.java
@@ -32,7 +32,6 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 import org.eclipse.ui.internal.browser.BrowserManager;
 import org.eclipse.ui.internal.browser.IBrowserDescriptor;
@@ -68,10 +67,8 @@ public class WebBrowserSelectionDialog extends MessageDialog {
         GridData data = new GridData(SWT.FILL, SWT.FILL, true, true);
         composite.setLayoutData(data);
         
-        Text label = new Text(composite, SWT.READ_ONLY | SWT.SINGLE );
+        Label label = new Label(composite, SWT.NONE);
         label.setText(Messages.BrowserSelectionListLabel);
-        label.setBackground(composite.getBackground());
-        label.setForeground(composite.getForeground());
         
         updateWebBrowserCombo(composite);
         


### PR DESCRIPTION
Use Label instead of Text so the mnemonic works.  The label is followed by an entry field so does not need to be a Text widget.