### PR TITLE
CW Issue #1467: Improve install status error handling

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/CLIUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/CLIUtil.java
@@ -217,12 +217,12 @@ public class CLIUtil {
 				if (obj.has(ERROR_KEY)) {
 					String msg = String.format("The %s command failed with error: %s", Arrays.toString(command), obj.getString(ERROR_DESCRIPTION_KEY)); //$NON-NLS-1$
 					Logger.logError(msg);
-					throw new IOException(msg);
+					throw new IOException(obj.getString(ERROR_DESCRIPTION_KEY));
 				}
 				if (obj.has(STATUS_KEY) && !STATUS_OK_VALUE.equals(obj.getString(STATUS_KEY))) {
 					String msg = String.format("The %s command failed with error: %s", Arrays.toString(command), obj.getString(STATUS_MSG_KEY)); //$NON-NLS-1$
 					Logger.logError(msg);
-					throw new IOException(msg);
+					throw new IOException(obj.getString(STATUS_MSG_KEY));
 				}
 			}
 		} catch (JSONException e) {

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
@@ -28,12 +28,7 @@ public class Messages extends NLS {
 	public static String Connection_JobError;
 	public static String Connection_TaskLabel;
 	
-	public static String Connection_ErrConnection_AlreadyExists;
 	public static String Connection_ErrConnection_OldVersion;
-	public static String Connection_ErrConnection_VersionUnknown;
-	public static String Connection_ErrConnection_WorkspaceErr;
-	public static String Connection_ErrContactingServerDialogMsg;
-	public static String Connection_ErrContactingServerDialogTitle;
 	public static String Connection_ErrGettingProjectListTitle;
 	public static String Connection_ErrConnection_UpdateCacheException;
 	public static String Connection_ErrConnection_CodewindNotReady;

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
@@ -21,12 +21,7 @@ Connection_JobLabel=Connecting to {0}
 Connection_JobError=An error occurred trying to connect to {0} at: {1}.
 Connection_TaskLabel=Connecting to Codewind at: {0}
 
-Connection_ErrConnection_AlreadyExists=A Codewind connection already exists at {0}.
 Connection_ErrConnection_OldVersion=Version {0} of Codewind is not supported. A minimum of Version {1} is required.
-Connection_ErrConnection_VersionUnknown=The Codewind version could not be determined. A minimum of Version {0} is required.
-Connection_ErrConnection_WorkspaceErr=The location of your Codewind workspace could not be determined.
-Connection_ErrContactingServerDialogMsg=Failed to contact the Codewind server at {0}.
-Connection_ErrContactingServerDialogTitle=Error contacting Codewind server
 Connection_ErrGettingProjectListTitle=Error getting list of projects
 Connection_ErrConnection_UpdateCacheException=An error occurred while initializing the Codewind connection. Check the workspace logs.
 Connection_ErrConnection_CodewindNotReady=Codewind failed to go into the ready state. Try stopping and re-starting Codewind.

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -97,6 +97,7 @@ public class Messages extends NLS {
 	public static String CodewindStoppingQualifier;
 	public static String CodewindErrorQualifier;
 	public static String CodewindErrorMsg;
+	public static String CodewindErrorMsgWithDetails;
 	public static String CodewindNotInstalledMsg;
 	public static String CodewindWrongVersionQualifier;
 	public static String CodewindWrongVersionMsg;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -90,6 +90,7 @@ CodewindStartingQualifier=Starting
 CodewindStoppingQualifier=Stopping
 CodewindErrorQualifier=Error
 CodewindErrorMsg=Disconnected. Check that Codewind is running and then right click and select Refresh.
+CodewindErrorMsgWithDetails=Disconnected. Select to show details in status bar. Check that Codewind is running and then right click and select Refresh.
 CodewindNotInstalledMsg=Double click to download the Codewind images
 CodewindWrongVersionQualifier=Unsupported version: {0}
 CodewindWrongVersionMsg=Double click to update to version: {0}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorLabelProvider.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorLabelProvider.java
@@ -94,7 +94,8 @@ public class CodewindNavigatorLabelProvider extends LabelProvider implements ISt
 					return name + "[" + NLS.bind(Messages.CodewindWrongVersionQualifier, status.getInstalledVersions()) + "] (" +
 							NLS.bind(Messages.CodewindWrongVersionMsg, InstallUtil.getVersion());
 				} else if (status.isUnknown()) {
-					return name + " [" + Messages.CodewindErrorQualifier + "] (" + Messages.CodewindErrorMsg + ")";
+					String errorMsg = manager.getInstallerErrorMsg() != null ? Messages.CodewindErrorMsgWithDetails : Messages.CodewindErrorMsg;
+					return name + " [" + Messages.CodewindErrorQualifier + "] (" + errorMsg + ")";
 				} else {
 					return name + " [" + Messages.CodewindErrorQualifier + "] (" + Messages.CodewindErrorMsg + ")";
 				}
@@ -184,7 +185,8 @@ public class CodewindNavigatorLabelProvider extends LabelProvider implements ISt
 					styledString.append(" (" + NLS.bind(Messages.CodewindWrongVersionMsg, InstallUtil.getVersion()) + ")", StyledString.QUALIFIER_STYLER);
 				} else if (status.isUnknown()) {
 					styledString.append(" [" + Messages.CodewindErrorQualifier + "]", StyledString.DECORATIONS_STYLER);
-					styledString.append(" (" + Messages.CodewindErrorMsg + ")", ERROR_STYLER);
+					String errorMsg = manager.getInstallerErrorMsg() != null ? Messages.CodewindErrorMsgWithDetails : Messages.CodewindErrorMsg;
+					styledString.append(" (" + errorMsg + ")", ERROR_STYLER);
 				} else {
 					styledString.append(" [" + Messages.CodewindNotInstalledQualifier + "]", StyledString.DECORATIONS_STYLER);
 					styledString.append(" (" + Messages.CodewindNotInstalledMsg + ")", StyledString.QUALIFIER_STYLER);
@@ -275,7 +277,12 @@ public class CodewindNavigatorLabelProvider extends LabelProvider implements ISt
 	
     @Override
     public String getDescription(Object element) {
-    	if (element instanceof RemoteConnection) {
+    	if (element instanceof LocalConnection) {
+    		if (CodewindManager.getManager().getInstallStatus() == InstallStatus.UNKNOWN &&
+    				CodewindManager.getManager().getInstallerErrorMsg() != null) {
+    			return CodewindManager.getManager().getInstallerErrorMsg();
+    		}
+    	} else if (element instanceof RemoteConnection) { 
     		RemoteConnection connection = (RemoteConnection) element;
     		if (connection.getBaseURI() != null) {
     			return connection.getBaseURI().toString();


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/1467

- I did not want to pop up a dialog when there is an error as the user may be working on something else not related to Codewind so I am showing the error message in the status bar. Can make this hover help later (see https://github.com/eclipse/codewind/issues/655).
- Removed some messages that are no longer used