### PR TITLE
CW Issue #732: One more dark mode fix

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
@@ -99,4 +99,4 @@ ProcessHelperUnknownError=Unknown error
 UpgradeResultMigrated=The following projects were successfully migrated:
 UpgradeResultNotMigrated=Problems were encountered migrating these projects. Try manually adding them as existing projects to Codewind:
 
-ProjectErrorTitle=An problem occurred with the {0} project
+ProjectErrorTitle=A problem occurred with the {0} project

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
@@ -701,6 +701,7 @@ public class ApplicationOverviewEditorPart extends EditorPart {
 			text.setData(FormToolkit.KEY_DRAW_BORDER, Boolean.FALSE);
 			text.setText(Messages.AppOverviewEditorNotAvailable);
 			text.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, false, false));
+			IDEUtil.normalizeBackground(text, composite);
 	        
 			link = toolkit.createHyperlink(composite, "", SWT.WRAP);
 			link.setVisible(false);


### PR DESCRIPTION
- Fix the Application Endpoint text in the Application Overview page to have the correct background (tested on MAC and Windows)
- Also fixed a type in a message