### PR TITLE
CW Issue #1398: Don't send log requests if application is disposed

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
@@ -227,16 +227,24 @@ public class CodewindEclipseApplication extends CodewindApplication {
 	}
 	
 	@Override
-	public void dispose() {
-		// Clean up the launch
-		clearDebugger();
-		
-		// Clean up the consoles
-		List<IConsole> consoleList = new ArrayList<IConsole>(activeConsoles);
-		if (!consoleList.isEmpty()) {
-			IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
-			consoleManager.removeConsoles(consoleList.toArray(new IConsole[consoleList.size()]));
+	public synchronized void setEnabled(boolean enabled) {
+		super.setEnabled(enabled);
+		if (!enabled) {
+			// Clean up the launch
+			clearDebugger();
+			
+			// Clean up the consoles
+			if (!activeConsoles.isEmpty()) {
+				IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
+				consoleManager.removeConsoles(activeConsoles.toArray(new IConsole[activeConsoles.size()]));
+				activeConsoles.clear();
+			}
 		}
+	}
+
+	@Override
+	public void dispose() {
+		setEnabled(false);
 		
 		// Start project delete if requested
 		if (getDeleteContents()) {

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindSocket.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindSocket.java
@@ -472,7 +472,6 @@ public class CodewindSocket {
 			Logger.logError("No application found for project being closed: " + projectID); //$NON-NLS-1$
 			return;
 		}
-		app.dispose();
 		app.connection.refreshApps(app.projectID);
 		CoreUtil.updateApplication(app);
 	}

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/console/SocketConsole.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/console/SocketConsole.java
@@ -69,8 +69,15 @@ public class SocketConsole extends IOConsole {
 
 		socket.deregisterSocketConsole(this);
 
+		if (app.isAvailable()) {
+			try {
+				app.connection.requestDisableLogStream(app, logInfo);
+			} catch (Exception e) {
+				Logger.logError("Error disabling the log stream for: " + app.name, e); //$NON-NLS-1$
+			}
+		}
+		
 		try {
-			app.connection.requestDisableLogStream(app, logInfo);
 			outputStream.close();
 		} catch (Exception e) {
 			Logger.logError("Error closing console output stream for: " + this.getName(), e); //$NON-NLS-1$


### PR DESCRIPTION
- Check that the app is available before sending a disable log stream request
- Separate out dispose() from setEnabled() so not calling dispose on a project closed event (the call to refresh the app will call setEnabled()).
- Put the closing of the output stream in a separate try block to make sure it gets executed