### PR TITLE
CW Issue #1766:  Replace Jetty WebSocket library with OkHttp WebSocket library

### DIFF
--- a/dev/buildAll.gradle
+++ b/dev/buildAll.gradle
@@ -40,8 +40,9 @@ dependencies {
     corelibs "io.socket:socket.io-client:1.0.0"
 
     // corelibs "com.nimbusds:oauth2-oidc-sdk:6.5"
-	
-    fwlibs "org.eclipse.jetty.websocket:websocket-client:9.4.23.v20191118"
+
+    fwlibs "com.squareup.okhttp3:okhttp:3.8.1"
+    fwlibs "com.squareup.okio:okio:1.13.0"
 
 }
 

--- a/dev/org.eclipse.codewind.filewatchers.core/.classpath
+++ b/dev/org.eclipse.codewind.filewatchers.core/.classpath
@@ -3,14 +3,9 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="lib" path="lib/jetty-client-9.4.23.v20191118.jar"/>
-	<classpathentry kind="lib" path="lib/jetty-http-9.4.23.v20191118.jar"/>
-	<classpathentry kind="lib" path="lib/jetty-io-9.4.23.v20191118.jar"/>
-	<classpathentry kind="lib" path="lib/jetty-util-9.4.23.v20191118.jar"/>
-	<classpathentry kind="lib" path="lib/jetty-xml-9.4.23.v20191118.jar"/>
-	<classpathentry kind="lib" path="lib/websocket-api-9.4.23.v20191118.jar"/>
-	<classpathentry kind="lib" path="lib/websocket-client-9.4.23.v20191118.jar"/>
-	<classpathentry kind="lib" path="lib/websocket-common-9.4.23.v20191118.jar"/>
 	<classpathentry kind="lib" path="lib/org.json_1.0.0.v201011060100.jar"/>
+	<classpathentry kind="lib" path="lib/hamcrest-core-1.3.jar"/>
+	<classpathentry kind="lib" path="lib/okhttp-3.8.1.jar"/>
+	<classpathentry kind="lib" path="lib/okio-1.13.0.jar"/>
 	<classpathentry kind="output" path="build/classes"/>
 </classpath>

--- a/dev/org.eclipse.codewind.filewatchers.core/.classpath
+++ b/dev/org.eclipse.codewind.filewatchers.core/.classpath
@@ -4,7 +4,6 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="lib" path="lib/org.json_1.0.0.v201011060100.jar"/>
-	<classpathentry kind="lib" path="lib/hamcrest-core-1.3.jar"/>
 	<classpathentry kind="lib" path="lib/okhttp-3.8.1.jar"/>
 	<classpathentry kind="lib" path="lib/okio-1.13.0.jar"/>
 	<classpathentry kind="output" path="build/classes"/>

--- a/dev/org.eclipse.codewind.filewatchers.core/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.filewatchers.core/META-INF/MANIFEST.MF
@@ -5,13 +5,7 @@ Bundle-SymbolicName: org.eclipse.codewind.filewatchers.core;singleton:=true
 Bundle-Version: 1.2.1.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-ClassPath: .,
- lib/jetty-client-9.4.23.v20191118.jar,
- lib/jetty-http-9.4.23.v20191118.jar,
- lib/jetty-io-9.4.23.v20191118.jar,
- lib/jetty-util-9.4.23.v20191118.jar,
- lib/jetty-xml-9.4.23.v20191118.jar,
- lib/org.json_1.0.0.v201011060100.jar,
- lib/websocket-api-9.4.23.v20191118.jar,
- lib/websocket-client-9.4.23.v20191118.jar,
- lib/websocket-common-9.4.23.v20191118.jar
+ lib/okhttp-3.8.1.jar,
+ lib/okio-1.13.0.jar,
+ lib/org.json_1.0.0.v201011060100.jar
 Export-Package: org.eclipse.codewind.filewatchers.core

--- a/dev/org.eclipse.codewind.filewatchers.core/build.properties
+++ b/dev/org.eclipse.codewind.filewatchers.core/build.properties
@@ -1,14 +1,7 @@
 source.. = src/
 bin.includes = META-INF/,\
                .,\
-               lib/,\
-               lib/jetty-client-9.4.23.v20191118.jar,\
-               lib/jetty-http-9.4.23.v20191118.jar,\
-               lib/jetty-io-9.4.23.v20191118.jar,\
-               lib/jetty-util-9.4.23.v20191118.jar,\
-               lib/jetty-xml-9.4.23.v20191118.jar,\
-               lib/org.json_1.0.0.v201011060100.jar,\
-               lib/websocket-api-9.4.23.v20191118.jar,\
-               lib/websocket-client-9.4.23.v20191118.jar,\
-               lib/websocket-common-9.4.23.v20191118.jar
+               lib/okhttp-3.8.1.jar,\
+               lib/okio-1.13.0.jar,\
+               lib/org.json_1.0.0.v201011060100.jar
 bin.excludes = lib/.gitignore

--- a/dev/org.eclipse.codewind.filewatchers.core/pom.xml
+++ b/dev/org.eclipse.codewind.filewatchers.core/pom.xml
@@ -8,9 +8,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.eclipse.jetty.websocket</groupId>
-			<artifactId>websocket-client</artifactId>
-			<version>9.4.23.v20191118</version>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>3.8.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.json</groupId>

--- a/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/Filewatcher.java
+++ b/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/Filewatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation
+ * Copyright (c) 2019, 2020 IBM Corporation
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -126,7 +126,6 @@ public class Filewatcher {
 
 		this.webSocketThread = new WebSocketManagerThread(wsUrl, this);
 		webSocketThread.start();
-		webSocketThread.queueEstablishConnection();
 
 		new DebugTimer(this);
 	}

--- a/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/WSClientEndpoint.java
+++ b/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/internal/WSClientEndpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation
+ * Copyright (c) 2019, 2020 IBM Corporation
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -11,19 +11,16 @@
 
 package org.eclipse.codewind.filewatchers.core.internal;
 
-import java.net.ConnectException;
+import java.io.EOFException;
+import java.net.SocketException;
 
 import org.eclipse.codewind.filewatchers.core.FWLogger;
-import org.eclipse.jetty.websocket.api.Session;
-import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
-import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
-import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
-import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
-import org.eclipse.jetty.websocket.api.annotations.WebSocket;
+
+import okhttp3.Response;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
 
 /**
- * Implements the Java WebSocket Endpoint API using the Jetty WS Client library.
- * 
  * On connection success, this class informs of its parent of the success.
  * 
  * On connection failure, this class informs its parent so that a new connection
@@ -33,8 +30,7 @@ import org.eclipse.jetty.websocket.api.annotations.WebSocket;
  * use that message (likely containing watch changes) to update the
  * ProjectToWatch list.
  */
-@WebSocket
-public class JettyClientEndpoint {
+public class WSClientEndpoint extends WebSocketListener {
 
 	private static final FWLogger log = FWLogger.getInstance();
 	private final WebSocketManagerThread parent;
@@ -42,31 +38,30 @@ public class JettyClientEndpoint {
 	/** For debug purposes. */
 	private final String wsUrl;
 
-	public JettyClientEndpoint(WebSocketManagerThread parent, String wsUrl) {
+	public WSClientEndpoint(WebSocketManagerThread parent, String wsUrl) {
 		this.parent = parent;
 		this.wsUrl = wsUrl;
 	}
 
-	@OnWebSocketConnect
-	public void onConnect(Session session) {
+	@Override
+	public void onOpen(WebSocket webSocket, Response response) {
 		log.logInfo("WebSocket connection opened for " + wsUrl);
 		if (parent != null) {
-			parent.setSessionFromEndpoint(session);
+			parent.informConnectionSuccess(webSocket);
 		}
 	}
 
-	@OnWebSocketClose
-	public void onClose(int statusCode, String reason) {
-		log.logInfo("WebSocket connection closed with reason: " + statusCode + " " + reason + ", for url: " + wsUrl);
+	@Override
+	public void onClosing(WebSocket webSocket, int code, String reason) {
+		log.logInfo("WebSocket connection closed with reason: " + code + " " + reason + ", for url: " + wsUrl);
+
 		if (parent != null) {
-			parent.setSessionFromEndpoint(null);
-			parent.queueEstablishConnection();
-			parent.informConnectionFail();
+			parent.informConnectionClosedOrFailed(webSocket);
 		}
 	}
 
-	@OnWebSocketMessage
-	public void onMessage(String msg) {
+	@Override
+	public void onMessage(WebSocket webSocket, String msg) {
 
 		if (parent != null) {
 			parent.receiveMessage(msg);
@@ -74,16 +69,35 @@ public class JettyClientEndpoint {
 
 	}
 
-	@OnWebSocketError
-	public void onError(Throwable thr) {
+	@Override
+	public void onFailure(WebSocket webSocket, Throwable thr, Response response) {
 
-		if (thr instanceof ConnectException && thr.getMessage().contains("Connection refused")) {
-			log.logError("WebSocket onError throwable: " + thr + " for url: " + wsUrl);
-			// Don't print stack trace for known message
-		} else {
+		// Only print the throwable if we don't recognize it as a standard failure
+		// scenario.
+		boolean printThrowable = true;
+
+		if (thr.getMessage() != null) {
+			if (thr.getMessage().contains("Failed to connect to ")) {
+				printThrowable = false;
+			}
+		}
+
+		if (thr instanceof EOFException || thr instanceof SocketException) {
+			printThrowable = false;
+		}
+
+		if (printThrowable) {
 			log.logSevere("WebSocket onError throwable: " + thr + " for url: " + wsUrl);
 			thr.printStackTrace();
+		} else {
+			log.logError("WebSocket onError - Unable to connect for url: " + wsUrl);
+
 		}
+
+		if (parent != null) {
+			parent.informConnectionClosedOrFailed(webSocket);
+		}
+
 	}
 
 }

--- a/dev/org.eclipse.codewind.filewatchers.standalonenio/src/org/eclipse/codewind/filewatchers/Main.java
+++ b/dev/org.eclipse.codewind.filewatchers.standalonenio/src/org/eclipse/codewind/filewatchers/Main.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation
+ * Copyright (c) 2019, 2020 IBM Corporation
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -16,11 +16,9 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.UUID;
 
-import org.eclipse.codewind.filewatchers.core.FWAuthToken;
 import org.eclipse.codewind.filewatchers.core.FWLogger;
 import org.eclipse.codewind.filewatchers.core.Filewatcher;
 import org.eclipse.codewind.filewatchers.core.FilewatcherUtils;
-import org.eclipse.codewind.filewatchers.core.IAuthTokenProvider;
 import org.eclipse.codewind.filewatchers.core.IPlatformWatchService;
 
 public class Main {
@@ -30,7 +28,7 @@ public class Main {
 		String url;
 
 		if (args.length == 0) {
-			url = "http://localhost:9090";
+			url = "https://localhost:9090";
 
 		} else if (args.length == 1) {
 			url = args[1];


### PR DESCRIPTION
I'm using the exact same versions of the OkHttp dependency as the Codewind Eclipse libraries, so as to avoid any package incompatibilities.

Testing:
- Passes all the standard Filewatcherd automated tests (both the regular and 'chaos engineering' version of these tests).
- Manual testing in Eclipse (local and remote)
- Confirmed it works with both IBM and Oracle JDK (Jetty previously had issues with IBM JDK due to differing TLS/SSL cert names, fortunately not the case here)

Parent issue: https://github.com/eclipse/codewind/issues/1766

