### PR TITLE
CW Issue #862: Fix Eclipse project name vs Codewind project name issues

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -338,8 +338,8 @@ public class CodewindEclipseApplication extends CodewindApplication {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
-					IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(name);
-					if (project != null && project.exists() && project.getLocation().equals(fullLocalPath)) {
+					IProject project = CoreUtil.getEclipseProject(CodewindEclipseApplication.this);
+					if (project != null) {
 						project.delete(true, true, monitor);
 					} else if (fullLocalPath.toFile().exists()) {
 						FileUtil.deleteDirectory(fullLocalPath.toOSString(), true);

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CoreUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CoreUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
 
 package org.eclipse.codewind.core.internal;
 
+import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -19,6 +20,9 @@ import java.util.Scanner;
 
 import org.eclipse.codewind.core.CodewindCorePlugin;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -272,6 +276,16 @@ public class CoreUtil {
 		}
 		// This should not happen
 		Logger.logError("The user.home system property was null or empty.");
+		return null;
+	}
+	
+	public static IProject getEclipseProject(CodewindApplication app) {
+		IContainer[] containers = ResourcesPlugin.getWorkspace().getRoot().findContainersForLocationURI(new File(app.fullLocalPath.toOSString()).toURI());
+		for (IContainer container : containers) {
+			if (container instanceof IProject && ((IProject)container).isAccessible()) {
+				return (IProject)container;
+			}
+		}
 		return null;
 	}
     

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/FileUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/FileUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -105,6 +105,15 @@ public class FileUtil {
             throw new IOException("Directory cannot be removed.");
         }
     }
-
+    
+    public static String getCanonicalPath(String path) {
+        String canonicalPath = path;
+        try {
+            canonicalPath = (new File(path)).getCanonicalPath();
+        } catch (Exception e) {
+            Logger.log("Failed to get the canonical path for: " + path + ". " + e.getMessage());
+        }
+        return canonicalPath;
+    }
 
 }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/BindProjectAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/BindProjectAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -89,7 +89,7 @@ public class BindProjectAction implements IObjectActionDelegate {
 			return;
 		}
 		
-		BindProjectWizard wizard = new BindProjectWizard(connection, project.getLocation());
+		BindProjectWizard wizard = new BindProjectWizard(connection, project);
 		WizardDialog dialog = new WizardDialog(Display.getDefault().getActiveShell(), wizard);
 		if (dialog.open() == Window.CANCEL) {
 			// If connection is new (not already registered), then close it
@@ -108,7 +108,7 @@ public class BindProjectAction implements IObjectActionDelegate {
 	}
 	
 	private String getProjectError(CodewindConnection connection, IProject project) {
-		if (connection.getAppByName(project.getName()) != null) {
+		if (connection.getAppByLocation(project.getLocation()) != null) {
 			return NLS.bind(Messages.BindProjectAlreadyExistsError,  project.getName());
 		}
 		return null;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/CodewindInstall.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/CodewindInstall.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -272,7 +272,7 @@ public class CodewindInstall {
 						NLS.bind(Messages.InstallCodewindAddProjectMessage, project.getName()))) {
 					CodewindConnection connection = CodewindConnectionManager.getLocalConnection();
 					if (connection != null && connection.isConnected()) {
-						Wizard wizard = new BindProjectWizard(connection, project.getLocation());
+						Wizard wizard = new BindProjectWizard(connection, project);
 						WizardLauncher.launchWizardWithoutSelection(wizard);
 					} else {
 						Logger.logError("Codewind not installed or has unknown status when trying to bind project: " + project.getName()); //$NON-NLS-1$

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2019 IBM Corporation and others.
+# Copyright (c) 2018, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v2.0
 # which accompanies this distribution, and is available at
@@ -137,7 +137,7 @@ MoveProjectError=An error occurred while moving the {0} project from {1} to {2}.
 
 ProjectDeployedDialogShell=Manage Deployments
 ProjectDeployedDialogTitle=Project Already Deployed
-ProjectDeployedDialogMessage=The {0} project is already deployed and enabled on other connections. It is not recommended to have the same project on multiple connections.
+ProjectDeployedDialogMessage=The project at location {0} is already deployed and enabled on other connections. It is not recommended to have the same project on multiple connections.
 ProjectDeployedDialogGroupLabel=Choose the behaviour for existing enabled deployments
 ProjectDeployedDialogRemoveLabel=Remove
 ProjectDeployedDialogRemoveTooltip=Remove any existing enabled deployments
@@ -208,7 +208,7 @@ SelectProjectPageBrowseButton=&Browse...
 SelectProjectPageFilesystemDialogTitle=Select a file system project in the Codewind workspace
 SelectProjectPageNoExistError=The selected path does not exist in the file system
 SelectProjectPageLocationError=Choose a project directly in the Codewind workspace folder: {0}
-SelectProjectPageCWProjectExistsError=A Codewind project already exists with the name: {0}
+SelectProjectPageCWProjectExistsError=A Codewind project already exists for location: {0}
 SelectProjectPageProjectExistsError=A workspace project already exists with the name: {0}
 
 ProjectValidationPageName=Project Type Detection

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorLabelProvider.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@ package org.eclipse.codewind.ui.internal.views;
 
 import org.eclipse.codewind.core.internal.CodewindApplication;
 import org.eclipse.codewind.core.internal.CodewindManager;
+import org.eclipse.codewind.core.internal.CoreUtil;
 import org.eclipse.codewind.core.internal.cli.InstallStatus;
 import org.eclipse.codewind.core.internal.cli.InstallUtil;
 import org.eclipse.codewind.core.internal.connection.LocalConnection;
@@ -23,6 +24,7 @@ import org.eclipse.codewind.core.internal.constants.ProjectLanguage;
 import org.eclipse.codewind.core.internal.constants.ProjectType;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.messages.Messages;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.preference.JFacePreferences;
 import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.jface.viewers.DelegatingStyledCellLabelProvider.IStyledLabelProvider;
@@ -116,6 +118,10 @@ public class CodewindNavigatorLabelProvider extends LabelProvider implements ISt
 		} else if (element instanceof CodewindApplication) {
 			CodewindApplication app = (CodewindApplication)element;
 			StringBuilder builder = new StringBuilder(app.name);
+			IProject project = CoreUtil.getEclipseProject(app);
+			if (project != null && !project.getName().equals(app.name)) {
+				builder.append("(" + project.getName() + ")");
+			}
 			
 			if (app.isEnabled()) {
 				AppStatus appStatus = app.getAppStatus();
@@ -212,6 +218,10 @@ public class CodewindNavigatorLabelProvider extends LabelProvider implements ISt
 		} else if (element instanceof CodewindApplication) {
 			CodewindApplication app = (CodewindApplication)element;
 			styledString = new StyledString(app.name);
+			IProject project = CoreUtil.getEclipseProject(app);
+			if (project != null && !project.getName().equals(app.name)) {
+				styledString.append("(" + project.getName() + ")");
+			}
 			
 			if (app.isEnabled()) {
 				AppStatus appStatus = app.getAppStatus();

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectDeployedDialog.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectDeployedDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@ package org.eclipse.codewind.ui.internal.wizards;
 
 import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.messages.Messages;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.dialogs.TitleAreaDialog;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
@@ -35,12 +36,12 @@ public class ProjectDeployedDialog extends TitleAreaDialog {
 		MAINTAIN
 	};
 	
-	private final String appName;
+	private final IPath projectPath;
 	private Behaviour selectedBehaviour = Behaviour.REMOVE;
 	
-	public ProjectDeployedDialog(Shell parentShell, String appName) {
+	public ProjectDeployedDialog(Shell parentShell, IPath projectPath) {
 		super(parentShell);
-		this.appName = appName;
+		this.projectPath = projectPath;
 	}
 	
 	@Override
@@ -57,7 +58,7 @@ public class ProjectDeployedDialog extends TitleAreaDialog {
 	protected Control createDialogArea(Composite parent) {
 		setTitleImage(CodewindUIPlugin.getImage(CodewindUIPlugin.CODEWIND_BANNER));
 		setTitle(Messages.ProjectDeployedDialogTitle);
-		setMessage(NLS.bind(Messages.ProjectDeployedDialogMessage, appName));
+		setMessage(NLS.bind(Messages.ProjectDeployedDialogMessage, projectPath.toOSString()));
 		
 		final Composite composite = new Composite(parent, SWT.NONE);
 		GridLayout layout = new GridLayout();

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectSelectionPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectSelectionPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -326,7 +326,7 @@ public class ProjectSelectionPage extends WizardPage {
 		if (!pattern.matches(project.getName())) {
 			return false;
 		}
-		if (connection.getAppByName(project.getName()) != null) {
+		if (connection.getAppByLocation(project.getLocation()) != null) {
 			return false;
 		}
 		return true;
@@ -356,9 +356,9 @@ public class ProjectSelectionPage extends WizardPage {
 					errorMsg = Messages.SelectProjectPageNoExistError;
 					projectPath = null;
 				} else {
-					if (connection.getAppByName(path.lastSegment()) != null) {
-						// It is an error if a Codewind project already exists with the same name
-						errorMsg = NLS.bind(Messages.SelectProjectPageCWProjectExistsError, path.lastSegment());
+					if (connection.getAppByLocation(path) != null) {
+						// It is an error if a Codewind project already exists with the same location
+						errorMsg = NLS.bind(Messages.SelectProjectPageCWProjectExistsError, path);
 						projectPath = null;
 					} else {
 						// It is an error if a project exists with the same name but has a different location
@@ -390,12 +390,16 @@ public class ProjectSelectionPage extends WizardPage {
 	@Override
 	public IWizardPage getNextPage() {
 		// Set the project so the next page has it.
-		wizard.setProjectPath(getProjectPath());
+		wizard.setProject(project, getProjectPath());
 		return super.getNextPage();
 	}
 
 	public boolean canFinish() {
 		return project != null || projectPath != null;
+	}
+	
+	public IProject getProject() {
+		return project;
 	}
 	
 	public IPath getProjectPath() {


### PR DESCRIPTION
- Fix problems where the code is looking up the Codewind application using the Eclipse project name. Use the location instead (project delete, filewatcher, etc.).
- Fix code to use the Eclipse project name when binding an existing project rather than the last segment of the project path.  The last segment of the project path will still be used if the user is binding a project from the file system.
- The problem of creating a project with one name but then specifying a location where the last segment of the path is a different name cannot be fixed because of the limitations of smart import (it does not provide a way to specify a project name). So for this case if the Eclipse project name is different from the Codewind project name then both are shown in the view as: `<Codewind project name>(<Eclipse project name>)`