### PR TITLE
CW Issue #1073: Get project capabilities and logs only when Turbine is ready

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
@@ -54,6 +54,7 @@ public class CodewindApplication {
 	private boolean injectMetrics = false;
 	private boolean enabled = true;
 	private String containerId;
+	private boolean capabilitiesReady = false;
 	private ProjectCapabilities projectCapabilities;
 	private String action;
 	private List<ProjectLogInfo> logInfos = new ArrayList<ProjectLogInfo>();
@@ -471,6 +472,14 @@ public class CodewindApplication {
 	public synchronized boolean getDeleteContents() {
 		return deleteContents;
 	}
+	
+	public synchronized void setCapabilitiesReady(boolean capabilitiesReady) {
+		this.capabilitiesReady = capabilitiesReady;
+	}
+	
+	public synchronized boolean getCapabilitiesReady() {
+		return capabilitiesReady;
+	}
 
 	/**
 	 * Get the capabilities of a project.  Cache them because they should not change
@@ -478,7 +487,7 @@ public class CodewindApplication {
 	 * needs to be fast.
 	 */
 	public ProjectCapabilities getProjectCapabilities() {
-		if (projectCapabilities == null) {
+		if (projectCapabilities == null && capabilitiesReady) {
 			try {
 				JSONObject obj = connection.requestProjectCapabilities(this);
 				projectCapabilities = new ProjectCapabilities(obj);

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplicationFactory.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplicationFactory.java
@@ -286,6 +286,11 @@ public class CodewindApplicationFactory {
 				app.setAutoBuild(appJso.getBoolean(CoreConstants.KEY_AUTO_BUILD));
 			}
 			
+			// Set capabilities ready
+			if (appJso.has(CoreConstants.KEY_CAPABILITIES_READY)) {
+				app.setCapabilitiesReady(appJso.getBoolean(CoreConstants.KEY_CAPABILITIES_READY));
+			}
+			
 			// Set inject metrics
 			if (appJso.has(CoreConstants.KEY_INJECT_METRICS)) {
 				app.setInjectMetrics(appJso.getBoolean(CoreConstants.KEY_INJECT_METRICS));
@@ -295,9 +300,11 @@ public class CodewindApplicationFactory {
 		}
 		
 		try {
-			// Set the log information
-			List<ProjectLogInfo> logInfos = app.connection.requestProjectLogs(app);
-			app.setLogInfos(logInfos);
+			if (appJso.has(CoreConstants.KEY_LOGS) && appJso.getJSONObject(CoreConstants.KEY_LOGS).length() > 0) {
+				// Set the log information
+				List<ProjectLogInfo> logInfos = app.connection.requestProjectLogs(app);
+				app.setLogInfos(logInfos);
+			}
 		} catch (Exception e) {
 			Logger.logError("An error occurred while updating the log information for project: " + app.name, e);
 		}

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/JSONObjectResult.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/JSONObjectResult.java
@@ -29,6 +29,10 @@ public abstract class JSONObjectResult {
 		this.type = type;
 	}
 	
+	protected boolean hasKey(String key) {
+		return result.has(key);
+	}
+	
 	protected String getString(String key) {
 		String value = null;
 		if (result.has(key)) {

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/ProjectTemplateInfo.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/ProjectTemplateInfo.java
@@ -50,7 +50,11 @@ public class ProjectTemplateInfo extends JSONObjectResult {
 	}
 	
 	public String getProjectStyle() {
-		String style = getString(PROJECT_STYLE_KEY);
+		// Get the style if it is there otherwise default to Codewind style
+		String style = null;
+		if (hasKey(PROJECT_STYLE_KEY)) {
+			style = getString(PROJECT_STYLE_KEY);
+		}
 		if (style == null || style.isEmpty()) {
 			style = CODEWIND_STYLE;
 		}

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/CoreConstants.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/CoreConstants.java
@@ -54,6 +54,7 @@ public class CoreConstants {
 			KEY_CONTAINER_ID = "containerId",
 			KEY_IS_HTTPS = "isHttps",
 			KEY_INJECT_METRICS = "injectMetrics",
+			KEY_CAPABILITIES_READY = "capabilitiesReady",
 
 			KEY_BUILD_LOG = "build-log",
 			KEY_BUILD_LOG_LAST_MODIFIED = "build-log-last-modified",

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
@@ -397,7 +397,7 @@ public class ApplicationOverviewEditorPart extends EditorPart {
 			if (app.supportsDebug()) {
 				hostDebugPort = app.isAvailable() && app.getDebugPort() > 0 ? Integer.toString(app.getDebugPort()) : null;
 			} else {
-				hostDebugPort = Messages.AppOverviewEditorDebugNotSupported;
+				hostDebugPort = app.getCapabilitiesReady() ? Messages.AppOverviewEditorDebugNotSupported : null;
 			}
 			hostDebugPortEntry.setValue(hostDebugPort, true);
 			projectIdEntry.setValue(app.projectID, true);
@@ -523,7 +523,7 @@ public class ApplicationOverviewEditorPart extends EditorPart {
 			if (app.supportsDebug()) {
 				debugPort = app.getContainerDebugPort();
 			} else {
-				debugPort = Messages.AppOverviewEditorDebugNotSupported;
+				debugPort = app.getCapabilitiesReady() ? Messages.AppOverviewEditorDebugNotSupported : null;
 			}
 			debugPortEntry.setValue(debugPort, true);
 			boolean hasSettingsFile = hasSettingsFile(app);


### PR DESCRIPTION
Don't try to get the project capabilities or logs until Turbine is ready. Also fixed a problem where it was logging an error that the projectStyle key was missing from the template info (it is never there for Codewind templates).