### PR TITLE
CW Issue #1732: Just use the project name for the app status notify dialog

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplicationFactory.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplicationFactory.java
@@ -177,7 +177,7 @@ public class CodewindApplicationFactory {
 									type = CoreUtil.DialogType.INFO;
 								}
 							}
-							CoreUtil.openDialog(type, NLS.bind(Messages.ProjectErrorTitle, app.name), detail);
+							CoreUtil.openDialog(type, app.name, detail);
 						}
 					}
 				}

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
@@ -104,8 +104,6 @@ public class Messages extends NLS {
 	
 	public static String UpgradeResultMigrated;
 	public static String UpgradeResultNotMigrated;
-	
-	public static String ProjectErrorTitle;
 
 	static {
 		// initialize resource bundle

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
@@ -98,4 +98,3 @@ ProcessHelperUnknownError=Unknown error
 UpgradeResultMigrated=The following projects were successfully migrated:
 UpgradeResultNotMigrated=Problems were encountered migrating these projects. Try manually adding them as existing projects to Codewind:
 
-ProjectErrorTitle=A problem occurred with the {0} project


### PR DESCRIPTION
Instead of using 'A problem occurred with ... project' in the app status notify dialog, just use the project name since the message may just be a warning or informationa.