### PR TITLE
CW Issue #1771: Fix missing null check for projectInfo

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/BindProjectWizard.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/BindProjectWizard.java
@@ -228,7 +228,7 @@ public class BindProjectWizard extends Wizard implements INewWizard {
 						// call validate again with type and subtype hint
 						// allows it to run extension commands if defined for that type and subtype
 						if (subtypeInfo != null) {
-							ProjectUtil.validateProject(name, path, typeInfo + ":" + subtypeInfo.id, connection.getConid(), mon.split(10));
+							ProjectUtil.validateProject(name, path, typeInfo.getId() + ":" + subtypeInfo.id, connection.getConid(), mon.split(10));
 						}
 						mon.setWorkRemaining(40);
 						ProjectUtil.bindProject(name, path, language, typeInfo.getId(), connection.getConid(), mon.split(20));

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectTypeSelectionPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectTypeSelectionPage.java
@@ -256,8 +256,13 @@ public class ProjectTypeSelectionPage extends WizardPage {
 	
 	public void setProjectInfo(ProjectInfo projectInfo) {
 		this.projectInfo = projectInfo;
-		projectTypeInfo = typeMap.get(projectInfo.type.getId());
-		projectSubtypeInfo = projectTypeInfo.new ProjectSubtypeInfo(projectInfo.language.getId());
+		if (projectInfo == null) {
+			projectTypeInfo = null;
+			projectSubtypeInfo = null;
+		} else {
+			projectTypeInfo = typeMap.get(projectInfo.type.getId());
+			projectSubtypeInfo = projectTypeInfo.new ProjectSubtypeInfo(projectInfo.language.getId());
+		}
 		updateTables(true);
 	}
 

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectValidationPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectValidationPage.java
@@ -44,6 +44,7 @@ public class ProjectValidationPage extends WizardPage {
 	private IPath projectPath;
 	private ProjectInfo projectInfo;
 	private Text validateMsg;
+	private Label typeLabel, languageLabel;
 	private Text typeText, languageText;
 	private Font boldFont;
 
@@ -80,7 +81,7 @@ public class ProjectValidationPage extends WizardPage {
 		
 		boldFont = IDEUtil.getBoldFont(getShell(), getFont());
         
-		Label typeLabel = new Label(composite, SWT.NONE);
+		typeLabel = new Label(composite, SWT.NONE);
 		typeLabel.setText("Type:");
 		data = new GridData(GridData.END, GridData.CENTER, false, false);
 		data.horizontalIndent = 20;
@@ -92,7 +93,7 @@ public class ProjectValidationPage extends WizardPage {
 		typeText.setLayoutData(new GridData(GridData.FILL, GridData.CENTER, true, false));
 		IDEUtil.normalizeBackground(typeText, composite);
 		
-		Label languageLabel = new Label(composite, SWT.NONE);
+		languageLabel = new Label(composite, SWT.NONE);
 		languageLabel.setText("Language:");
 		data = new GridData(GridData.END, GridData.CENTER, false, false);
 		data.horizontalIndent = 20;
@@ -162,18 +163,23 @@ public class ProjectValidationPage extends WizardPage {
 			validateMsg.setText(NLS.bind(Messages.ProjectValidationPageMsg, getProjectName()));
 			typeText.setText(projectInfo.type.getDisplayName());
 			IDEUtil.normalizeBackground(typeText, typeText.getParent());
+			typeLabel.setVisible(true);
 			typeText.setVisible(true);
 			
 			if (projectInfo.language != ProjectLanguage.LANGUAGE_UNKNOWN) {
 				languageText.setText(projectInfo.language.getDisplayName());
 				IDEUtil.normalizeBackground(languageText, languageText.getParent());
+				languageLabel.setVisible(true);
 				languageText.setVisible(true);
 			} else {
+				languageLabel.setVisible(false);
 				languageText.setVisible(false);
 			}
 		} else {
 			validateMsg.setText(Messages.ProjectValidationPageFailMsg);
+			typeLabel.setVisible(false);
 			typeText.setVisible(false);
+			languageLabel.setVisible(false);
 			languageText.setVisible(false);
 		}
 		


### PR DESCRIPTION
A problem with PR https://github.com/eclipse/codewind-eclipse/pull/516 (looks like conid may be needed on validate after all) showed that after adding null checks for projectInfo I missed one on my own new code. Also fixed a problem where the labels are showing if projectInfo is null and an issue with the validate call where it should be passing in the type id (not the type object).