### PR TITLE
CW Issue #1801: Add the conid option back to cwctl project validate

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/ProjectUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/ProjectUtil.java
@@ -93,8 +93,8 @@ public class ProjectUtil {
 		Process process = null;
 		try {
 			process = (hint == null) ?
-					CLIUtil.runCWCTL(CLIUtil.GLOBAL_INSECURE, VALIDATE_CMD, new String[] {PATH_OPTION, path}) :
-					CLIUtil.runCWCTL(CLIUtil.GLOBAL_INSECURE, VALIDATE_CMD, new String[] {TYPE_OPTION, hint, PATH_OPTION, path});
+					CLIUtil.runCWCTL(CLIUtil.GLOBAL_INSECURE, VALIDATE_CMD, new String[] {PATH_OPTION, path, CLIUtil.CON_ID_OPTION, conid}) :
+					CLIUtil.runCWCTL(CLIUtil.GLOBAL_INSECURE, VALIDATE_CMD, new String[] {TYPE_OPTION, hint, PATH_OPTION, path, CLIUtil.CON_ID_OPTION, conid});
 			ProcessResult result = ProcessHelper.waitForProcess(process, 500, 300, mon);
 			if (result.getExitValue() != 0) {
 				Logger.logError("Project validate failed with rc: " + result.getExitValue() + " and error: " + result.getErrorMsg()); //$NON-NLS-1$ //$NON-NLS-2$

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectLanguage.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectLanguage.java
@@ -15,6 +15,7 @@ import java.util.EnumSet;
 
 public enum ProjectLanguage {
 	LANGUAGE_JAVA("java", "Java"),
+	LANGUAGE_JAVASCRIPT("javascript", "JavaScript"),
 	LANGUAGE_NODEJS("nodejs", "Node.js"),
 	LANGUAGE_SWIFT("swift", "Swift"),
 	LANGUAGE_PYTHON("python", "Python"),


### PR DESCRIPTION
Put the conid option back on calls to the cwctl project validate command. Also added the `javascript` language as node.js projects now have this as the language.