### PR TITLE
CW Issue #1809: Support JavaScript as a language

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/CodewindCorePlugin.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/CodewindCorePlugin.java
@@ -21,7 +21,6 @@ import org.eclipse.codewind.core.internal.IUpdateHandler;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.cli.InstallUtil;
 import org.eclipse.codewind.core.internal.connection.CodewindConnectionManager;
-import org.eclipse.codewind.core.internal.constants.ProjectLanguage;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.osgi.service.debug.DebugOptionsListener;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
@@ -55,7 +54,7 @@ public class CodewindCorePlugin extends AbstractUIPlugin {
 	
 	private static IUpdateHandler updateHandler;
 	
-	private static Map<ProjectLanguage, IDebugLauncher> debugLaunchers = new HashMap<ProjectLanguage, IDebugLauncher>();
+	private static Map<String, IDebugLauncher> debugLaunchers = new HashMap<String, IDebugLauncher>();
 
 	/**
 	 * The constructor
@@ -118,11 +117,11 @@ public class CodewindCorePlugin extends AbstractUIPlugin {
 		return updateHandler;
 	}
 	
-	public static void addDebugLauncher(ProjectLanguage language, IDebugLauncher launcher) {
-		debugLaunchers.put(language, launcher);
+	public static void addDebugLauncher(String languageId, IDebugLauncher launcher) {
+		debugLaunchers.put(languageId, launcher);
 	}
 	
-	public static IDebugLauncher getDebugLauncher(ProjectLanguage language) {
-		return debugLaunchers.get(language);
+	public static IDebugLauncher getDebugLauncher(String languageId) {
+		return debugLaunchers.get(languageId);
 	}
 }

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
@@ -383,7 +383,7 @@ public class CodewindApplication {
 	public synchronized boolean hasAppMonitor() {
 		// Metrics available is really: metrics are in the package.json/pom.xml/package.swift
 		// thus it can be false even when injectMetrics is true so need to check both
-		return ProjectLanguage.alwaysHasAppMonitor(projectLanguage) || getMetricsAvailable() || injectMetrics;
+		return projectLanguage.alwaysHasAppMonitor() || getMetricsAvailable() || injectMetrics;
 	}
 	
 	public synchronized boolean hasPerfDashboard() {

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
@@ -12,9 +12,7 @@
 package org.eclipse.codewind.core.internal;
 
 import java.net.MalformedURLException;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.eclipse.codewind.core.CodewindCorePlugin;
@@ -140,7 +138,7 @@ public class CodewindEclipseApplication extends CodewindApplication {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
-					if (app.projectLanguage == ProjectLanguage.LANGUAGE_JAVA) {
+					if (app.projectLanguage.isJava()) {
 						ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
 				        ILaunchConfigurationType launchConfigurationType = launchManager.getLaunchConfigurationType(CodewindLaunchConfigDelegate.LAUNCH_CONFIG_ID);
 				        ILaunchConfigurationWorkingCopy workingCopy = launchConfigurationType.newInstance((IContainer) null, app.name);
@@ -150,7 +148,7 @@ public class CodewindEclipseApplication extends CodewindApplication {
 			            app.setLaunch(launch);
 			            return Status.OK_STATUS;
 					} else {
-						IDebugLauncher launcher = CodewindCorePlugin.getDebugLauncher(app.projectLanguage);
+						IDebugLauncher launcher = CodewindCorePlugin.getDebugLauncher(app.projectLanguage.getId());
 						if (launcher != null) {
 							return launcher.launchDebugger(app);
 						}
@@ -188,11 +186,11 @@ public class CodewindEclipseApplication extends CodewindApplication {
 	}
 	
 	public boolean canAttachDebugger() {
-		if (projectLanguage == ProjectLanguage.LANGUAGE_JAVA) {
+		if (projectLanguage.isJava()) {
 			IDebugTarget debugTarget = getDebugTarget();
 			return (debugTarget == null || debugTarget.isDisconnected());
 		} else {
-			IDebugLauncher launcher = CodewindCorePlugin.getDebugLauncher(projectLanguage);
+			IDebugLauncher launcher = CodewindCorePlugin.getDebugLauncher(projectLanguage.getId());
 			if (launcher != null) {
 				return launcher.canAttachDebugger(this);
 			}
@@ -311,7 +309,7 @@ public class CodewindEclipseApplication extends CodewindApplication {
 	@Override
 	public boolean supportsDebug() {
 		// Only supported for certain languages
-		if (projectLanguage == ProjectLanguage.LANGUAGE_JAVA || projectLanguage == ProjectLanguage.LANGUAGE_NODEJS) {
+		if (projectLanguage.isJava() || projectLanguage.isJavaScript()) {
 			// And only if the project supports it
 			ProjectCapabilities capabilities = getProjectCapabilities();
 			return (capabilities.supportsDebugMode() || capabilities.supportsDebugNoInitMode()) && capabilities.canRestart();

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/ProjectUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/ProjectUtil.java
@@ -93,8 +93,8 @@ public class ProjectUtil {
 		Process process = null;
 		try {
 			process = (hint == null) ?
-					CLIUtil.runCWCTL(CLIUtil.GLOBAL_INSECURE, VALIDATE_CMD, new String[] {PATH_OPTION, path}) :
-					CLIUtil.runCWCTL(CLIUtil.GLOBAL_INSECURE, VALIDATE_CMD, new String[] {TYPE_OPTION, hint, PATH_OPTION, path});
+					CLIUtil.runCWCTL(CLIUtil.GLOBAL_INSECURE, VALIDATE_CMD, new String[] {PATH_OPTION, path, CLIUtil.CON_ID_OPTION, conid}) :
+					CLIUtil.runCWCTL(CLIUtil.GLOBAL_INSECURE, VALIDATE_CMD, new String[] {TYPE_OPTION, hint, PATH_OPTION, path, CLIUtil.CON_ID_OPTION, conid});
 			ProcessResult result = ProcessHelper.waitForProcess(process, 500, 300, mon);
 			if (result.getExitValue() != 0) {
 				Logger.logError("Project validate failed with rc: " + result.getExitValue() + " and error: " + result.getErrorMsg()); //$NON-NLS-1$ //$NON-NLS-2$

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectLanguage.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectLanguage.java
@@ -11,19 +11,34 @@
 
 package org.eclipse.codewind.core.internal.constants;
 
-import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
 
-public enum ProjectLanguage {
-	LANGUAGE_JAVA("java", "Java"),
-	LANGUAGE_JAVASCRIPT("javascript", "JavaScript"),
-	LANGUAGE_NODEJS("nodejs", "Node.js"),
-	LANGUAGE_SWIFT("swift", "Swift"),
-	LANGUAGE_PYTHON("python", "Python"),
-	LANGUAGE_GO("go", "Go"),
-	LANGUAGE_BASH("bash", "Bash"),
-	LANGUAGE_UNKNOWN("unknown", "Unknown");
+import org.eclipse.codewind.core.internal.messages.Messages;
+
+public class ProjectLanguage {
 	
-	public static final EnumSet<ProjectLanguage> ALWAYS_HAS_APP_MONITOR = EnumSet.of(LANGUAGE_JAVA, LANGUAGE_NODEJS);
+	public static final ProjectLanguage LANGUAGE_JAVA = new ProjectLanguage("java", "Java");
+	public static final ProjectLanguage LANGUAGE_JAVASCRIPT = new ProjectLanguage("javascript", "JavaScript");
+	public static final ProjectLanguage LANGUAGE_NODEJS = new ProjectLanguage("nodejs", "Node.js");
+	public static final ProjectLanguage LANGUAGE_SWIFT = new ProjectLanguage("swift", "Swift");
+	public static final ProjectLanguage LANGUAGE_GO = new ProjectLanguage("go", "Go");
+	public static final ProjectLanguage LANGUAGE_PYTHON = new ProjectLanguage("python", "Python");
+	public static final ProjectLanguage LANGUAGE_BASH = new ProjectLanguage("bash", "Bash");
+	public static final ProjectLanguage LANGUAGE_UNKNOWN = new ProjectLanguage("unknown", Messages.GenericUnknown);
+	
+	private static final Map<String, ProjectLanguage> defaultLanguages = new HashMap<String, ProjectLanguage>();
+	
+	static {
+		defaultLanguages.put("java", LANGUAGE_JAVA);
+		defaultLanguages.put("javascript", LANGUAGE_JAVASCRIPT);
+		defaultLanguages.put("nodejs", LANGUAGE_NODEJS);
+		defaultLanguages.put("swift", LANGUAGE_SWIFT);
+		defaultLanguages.put("go", LANGUAGE_GO);
+		defaultLanguages.put("python", LANGUAGE_PYTHON);
+		defaultLanguages.put("bash", LANGUAGE_BASH);
+		defaultLanguages.put("unknown", LANGUAGE_UNKNOWN);
+	}
 	
 	private final String id;
 	private final String displayName;
@@ -41,43 +56,61 @@ public enum ProjectLanguage {
 		return displayName;
 	}
 	
-	public static ProjectLanguage getLanguage(String name) {
-		for (ProjectLanguage language : ProjectLanguage.values()) {
-			if (language.id.equals(name)) {
-				return language;
-			}
+	public static ProjectLanguage getLanguage(String id) {
+		ProjectLanguage language = id == null ? LANGUAGE_UNKNOWN : defaultLanguages.get(id);
+		if (language == null) {
+			language = new ProjectLanguage(id, id);
 		}
-		return LANGUAGE_UNKNOWN;
+		return language;
+	}
+	
+	public boolean isUnknown() {
+		return "unknown".equals(id);
+	}
+	
+	public boolean isJavaScript() {
+		return "javascript".equals(id) || "nodejs".equals(id);
+	}
+	
+	public boolean isJava() {
+		return "java".equals(id);
+	}
+	
+	public boolean isSwift() {
+		return "swift".equals(id);
+	}
+	
+	public boolean isGo() {
+		return "go".equals(id);
+	}
+	
+	public boolean isPython() {
+		return "python".equals(id);
 	}
 	
 	public String getMetricsRoot() {
-		switch(this) {
-			case LANGUAGE_NODEJS:
-				return "appmetrics-dash/?theme=dark";
-			case LANGUAGE_SWIFT:
-				return "swiftmetrics-dash/?theme=dark";
-			case LANGUAGE_JAVA:
-				return "javametrics-dash/?theme=dark";
-			default:
-				return null;
+		if (isJavaScript()) {
+			return "appmetrics-dash/?theme=dark";
+		} else if (isSwift()) {
+			return "swiftmetrics-dash/?theme=dark";
+		} else if (isJava()) {
+			return "javametrics-dash/?theme=dark";
 		}
+		return null;
 	}
 	
-	public static boolean alwaysHasAppMonitor(ProjectLanguage lang) {
-		if (lang == null) {
-			return false;
-		}
-		return ALWAYS_HAS_APP_MONITOR.contains(lang);
+	public boolean alwaysHasAppMonitor() {
+		return isJava() || isJavaScript();
 	}
 	
-	public static String getDisplayName(String languageId) {
-		if (languageId == null) {
-			return ProjectLanguage.LANGUAGE_UNKNOWN.getDisplayName();
+	public static String getDisplayName(String id) {
+		if (id == null) {
+			return Messages.GenericUnknown;
 		}
-		ProjectLanguage language = ProjectLanguage.getLanguage(languageId);
-		if (language != null && language != ProjectLanguage.LANGUAGE_UNKNOWN) {
+		ProjectLanguage language = defaultLanguages.get(id);
+		if (language != null) {
 			return language.getDisplayName();
 		}
-		return languageId;
+		return id;
 	}
 };

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectLanguage.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectLanguage.java
@@ -15,6 +15,7 @@ import java.util.EnumSet;
 
 public enum ProjectLanguage {
 	LANGUAGE_JAVA("java", "Java"),
+	LANGUAGE_JAVASCRIPT("javascript", "JavaScript"),
 	LANGUAGE_NODEJS("nodejs", "Node.js"),
 	LANGUAGE_SWIFT("swift", "Swift"),
 	LANGUAGE_PYTHON("python", "Python"),

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectType.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/ProjectType.java
@@ -102,20 +102,4 @@ public class ProjectType {
 		}
 		return getExtDisplayName(typeId);
 	}
-	
- 	public static ProjectType getTypeFromLanguage(String language) {
-		ProjectLanguage lang = ProjectLanguage.getLanguage(language);
-		switch(lang) {
-			case LANGUAGE_NODEJS:
-				return TYPE_NODEJS;
-			case LANGUAGE_SWIFT:
-				return TYPE_SWIFT;
-			case LANGUAGE_PYTHON:
-				return TYPE_DOCKER;
-			case LANGUAGE_GO:
-				return TYPE_DOCKER;
-			default:
-				return null;
-		}
-	} 
 }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/CodewindUIPlugin.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/CodewindUIPlugin.java
@@ -86,7 +86,8 @@ public class CodewindUIPlugin extends AbstractUIPlugin {
 		plugin = this;
 		updateHandler = new UpdateHandler();
 		CodewindCorePlugin.setUpdateHandler(updateHandler);
-		CodewindCorePlugin.addDebugLauncher(ProjectLanguage.LANGUAGE_NODEJS, new NodeJSDebugLauncher());
+		CodewindCorePlugin.addDebugLauncher(ProjectLanguage.LANGUAGE_NODEJS.getId(), new NodeJSDebugLauncher());
+		CodewindCorePlugin.addDebugLauncher(ProjectLanguage.LANGUAGE_JAVASCRIPT.getId(), new NodeJSDebugLauncher());
 	}
 
 	/*

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/AttachDebuggerAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/AttachDebuggerAction.java
@@ -41,7 +41,7 @@ public class AttachDebuggerAction extends SelectionProviderAction {
 			Object obj = sel.getFirstElement();
 			if (obj instanceof CodewindEclipseApplication) {
             	app = (CodewindEclipseApplication) obj;
-            	if (app.projectLanguage == ProjectLanguage.LANGUAGE_NODEJS) {
+            	if (app.projectLanguage.isJavaScript()) {
             		this.setText(Messages.LaunchDebugSessionLabel);
             	} else {
             		this.setText(Messages.AttachDebuggerLabel);

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RestartDebugModeAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RestartDebugModeAction.java
@@ -15,7 +15,6 @@ import org.eclipse.codewind.core.internal.CodewindEclipseApplication;
 import org.eclipse.codewind.core.internal.CoreUtil;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.constants.AppStatus;
-import org.eclipse.codewind.core.internal.constants.ProjectLanguage;
 import org.eclipse.codewind.core.internal.constants.StartMode;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.IDEUtil;
@@ -72,7 +71,7 @@ public class RestartDebugModeAction extends SelectionProviderAction {
         
         // Check for a project for Java applications only since currently this is the only
         // language that can be debugged within Eclipse
-        if (app.projectLanguage == ProjectLanguage.LANGUAGE_JAVA) {
+        if (app.projectLanguage.isJava()) {
 	        IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(app.name);
 	        // Check if the project has been imported into Eclipse. If not, offer to import it.
 	        if (project == null || !project.exists()) {

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorLabelProvider.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorLabelProvider.java
@@ -267,19 +267,17 @@ public class CodewindNavigatorLabelProvider extends LabelProvider implements ISt
 			} else if (type == ProjectType.TYPE_SWIFT) {
 					return CodewindUIPlugin.getImage(CodewindUIPlugin.SWIFT_ICON);
 			} else {
-					ProjectLanguage lang = ((CodewindApplication)element).projectLanguage;
-					switch (lang) {
-						case LANGUAGE_GO:
-							return CodewindUIPlugin.getImage(CodewindUIPlugin.GO_ICON);
-						case LANGUAGE_JAVA:
-							return CodewindUIPlugin.getImage(CodewindUIPlugin.JAVA_ICON);
-						case LANGUAGE_NODEJS:
-							return CodewindUIPlugin.getImage(CodewindUIPlugin.NODE_ICON);
-						case LANGUAGE_PYTHON:
-							return CodewindUIPlugin.getImage(CodewindUIPlugin.PYTHON_ICON);
-						default:
-							return CodewindUIPlugin.getImage(CodewindUIPlugin.GENERIC_PROJECT_ICON);
-					}
+				ProjectLanguage lang = ((CodewindApplication)element).projectLanguage;
+				if (lang.isGo()) {
+					return CodewindUIPlugin.getImage(CodewindUIPlugin.GO_ICON);
+				} else if (lang.isJava()) {
+					return CodewindUIPlugin.getImage(CodewindUIPlugin.JAVA_ICON);
+				} else if (lang.isJavaScript()) {
+					return CodewindUIPlugin.getImage(CodewindUIPlugin.NODE_ICON);
+				} else if (lang.isPython()) {
+					return CodewindUIPlugin.getImage(CodewindUIPlugin.PYTHON_ICON);
+				}
+				return CodewindUIPlugin.getImage(CodewindUIPlugin.GENERIC_PROJECT_ICON);
 			}
 		}
 		return null;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectValidationPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectValidationPage.java
@@ -166,7 +166,7 @@ public class ProjectValidationPage extends WizardPage {
 			typeLabel.setVisible(true);
 			typeText.setVisible(true);
 			
-			if (projectInfo.language != ProjectLanguage.LANGUAGE_UNKNOWN) {
+			if (!projectInfo.language.isUnknown()) {
 				languageText.setText(projectInfo.language.getDisplayName());
 				IDEUtil.normalizeBackground(languageText, languageText.getParent());
 				languageLabel.setVisible(true);


### PR DESCRIPTION
Support JavaScript as the new language for node.js projects.

Also cleaned up ProjectLanguage class so it can handle other languages which fixes https://github.com/eclipse/codewind/issues/1094 (ProjectType was already done).