### PR TITLE
CW Issue #1771: Missing null check on typeMap

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectTypeSelectionPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectTypeSelectionPage.java
@@ -259,7 +259,7 @@ public class ProjectTypeSelectionPage extends WizardPage {
 		if (projectInfo == null) {
 			projectTypeInfo = null;
 			projectSubtypeInfo = null;
-		} else {
+		} else if (typeMap != null) {
 			projectTypeInfo = typeMap.get(projectInfo.type.getId());
 			projectSubtypeInfo = projectTypeInfo.new ProjectSubtypeInfo(projectInfo.language.getId());
 		}


### PR DESCRIPTION
Need a null check on typeMap in ProjectTypeSelectionPage.setProjectInfo.  An NPE happens when the user right clicks a project in the Project Explorer view and selects Codewind > Add Project.  Looks like the typeMap is not initialized when setProjectInfo is called in this case.  The projectTypeInfo and projectSubtypeInfo will still get initialized in this case because updateTables is called right after typeMap is initialized.

Also opened this issue to clean up this class because the overloading of the language and subtype concepts makes the code complicated and confusing: https://github.com/eclipse/codewind/issues/1833.