### PR TITLE
Ensure UTF-8 encoding on strings received from cwctl

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/ProcessHelper.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/ProcessHelper.java
@@ -130,7 +130,7 @@ public class ProcessHelper {
     	int n = stream.available();
         while (n > 0) {
             int len = stream.read(buffer, 0, Math.min(n, buffer.length));
-            builder.append(new String(buffer, 0, len)); 
+            builder.append(new String(buffer, 0, len, "UTF-8"));
             n = stream.available();
         }
         return builder.toString();


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

Fixes https://github.com/eclipse/codewind/issues/1765

This change ensures that all Strings obtained from cwctl are encoded as UTF-8 strings rather than whatever the system default is.

# WARNING 
This change affects all interactions between the Eclipse Plugin and CWCTL. **Extensive Testing Required!**

@eharris369 Would you be so kind as to test and review please.