### PR TITLE
CW Issue #1861: Show swift icon for projects of that language

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -111,14 +111,8 @@ public class CodewindApplication {
 		String httpStr = getIsHttps() ? "https" : "http";
 		baseUrl = new URL(httpStr, host, httpPort, ""); //$NON-NLS-1$ //$NON-NLS-2$
 		
-		// If the app url was set in the project info, use it
-		URL appUrl = null;
-		if (appBaseUrl != null && !appBaseUrl.isEmpty()) {
-			appUrl = new URL(appBaseUrl);
-		}
-		rootUrl = appUrl != null ? appUrl : baseUrl;
-		
-		// Add the context root if there is one
+		// The root URL is the app base URL plus the context root if there is one
+		rootUrl = getAppBaseUrl();
 		if (contextRoot != null && !contextRoot.isEmpty()) {
 			rootUrl = new URL(rootUrl, contextRoot);
 		}
@@ -252,6 +246,14 @@ public class CodewindApplication {
 		return baseUrl;
 	}
 	
+	public URL getAppBaseUrl() throws MalformedURLException {
+		// If the app url was set in the project info, use it
+		if (appBaseUrl != null && !appBaseUrl.isEmpty()) {
+			return new URL(appBaseUrl);
+		}
+		return baseUrl;
+	}
+	
 	/**
 	 * Can return null if this project hasn't started yet (ie httpPort == -1)
 	 */
@@ -262,13 +264,7 @@ public class CodewindApplication {
 	public URL getMetricsUrl() {
 		try {
 			if ((!this.injectMetrics) && this.metricsAvailable) {
-				URL appUrl = null;
-				if (appBaseUrl != null && !appBaseUrl.isEmpty()) {
-					appUrl = new URL(appBaseUrl);
-				}
-				URL metricsBaseUrl = appUrl != null ? appUrl : baseUrl;
-				URL metricsUrl = new URL(metricsBaseUrl, projectLanguage.getMetricsRoot());
-				return metricsUrl;
+				return new URL(getAppBaseUrl(), projectLanguage.getMetricsRoot());
 			} else {
 				return (connection.getBaseURI().resolve(CoreConstants.PERF_METRICS_DASH + "/" + projectLanguage.getId() + "?theme=dark&projectID=" + projectID)).toURL();
 			}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorLabelProvider.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorLabelProvider.java
@@ -276,6 +276,8 @@ public class CodewindNavigatorLabelProvider extends LabelProvider implements ISt
 					return CodewindUIPlugin.getImage(CodewindUIPlugin.NODE_ICON);
 				} else if (lang.isPython()) {
 					return CodewindUIPlugin.getImage(CodewindUIPlugin.PYTHON_ICON);
+				} else if (lang.isSwift()) {
+					return CodewindUIPlugin.getImage(CodewindUIPlugin.SWIFT_ICON);
 				}
 				return CodewindUIPlugin.getImage(CodewindUIPlugin.GENERIC_PROJECT_ICON);
 			}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/CodewindConnectionComposite.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/CodewindConnectionComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -92,6 +92,8 @@ public class CodewindConnectionComposite extends Composite {
         
         createLabel(Messages.CodewindConnectionComposite_PasswordLabel, this, 1);
         connPassText = createConnText(this, SWT.PASSWORD, 1);
+        
+        new Label(this, SWT.NONE).setLayoutData(new GridData(GridData.FILL, GridData.FILL, false, false, 2, 1));
 		
 		Link learnMoreLink = new Link(this, SWT.NONE);
 		learnMoreLink.setText("<a>" + Messages.RegMgmtLearnMoreLink + "</a>"); //$NON-NLS-1$ //$NON-NLS-2$


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/1861

- Show the swift icon for projects with language set to swift
- Add space between the entry fields and the learn more link in the new connection composite
- Common up the code in CodewindApplication for calculating the app base url