### PR TITLE
CW Issue #1905: Improve the manage image registries dialog

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -470,8 +470,7 @@ public class Messages extends NLS {
 	public static String RegMgmtUsernameColumn;
 	public static String RegMgmtNamespaceColumn;
 	public static String RegMgmtPushRegColumn;
-	public static String RegMgmtPushRegTrue;
-	public static String RegMgmtPushRegFalse;
+	public static String RegMgmtPushRegSet;
 	
 	public static String RegMgmtAddDialogShell;
 	public static String RegMgmtAddDialogTitle;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -458,14 +458,13 @@ RegMgmtDescription=Provide registries for projects that need to pull content to 
 RegMgmtLocalDescription=Provide registries for projects that need to pull content to build.
 RegMgmtLearnMoreLink=Learn more...
 RegMgmtAddButton=&Add...
-RegMgmtSetPushButton=Set &Push
+RegMgmtSetPushButton=Set as &Push
 RegMgmtRemoveButton=&Remove
 RegMgmtAddressColumn=Address
 RegMgmtUsernameColumn=Username
 RegMgmtNamespaceColumn=Namespace
 RegMgmtPushRegColumn=Push Registry
-RegMgmtPushRegTrue=True
-RegMgmtPushRegFalse=False
+RegMgmtPushRegSet=Set
 
 RegMgmtAddDialogShell=Image Registries
 RegMgmtAddDialogTitle=Add Image Registry

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/RegistryManagementComposite.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/RegistryManagementComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -249,7 +249,9 @@ public class RegistryManagementComposite extends Composite {
 			if (supportsPushReg) {
 				item.setText(2, regEntry.namespace == null ? "" : regEntry.namespace); //$NON-NLS-1$
 				item.setForeground(2, regEntry.isPushReg ? item.getForeground() : getGray(item));
-				item.setText(3, regEntry.isPushReg ? Messages.RegMgmtPushRegTrue : Messages.RegMgmtPushRegFalse);
+				if (regEntry.isPushReg) {
+					item.setText(3, Messages.RegMgmtPushRegSet);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/1905

- Change the button from `Set Push` to `Set as Push`
- For the push registry show `Set` in the column and blank for non-push registries