### PR TITLE
CW Issue #1934: Run all log file actions in jobs

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/console/CodewindConsoleFactory.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/console/CodewindConsoleFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ public class CodewindConsoleFactory {
 
 	static final String CODEWIND_CONSOLE_TYPE = "codewind-console"; //$NON-NLS-1$
 
-	public static SocketConsole createLogFileConsole(CodewindApplication app, ProjectLogInfo logInfo) {
+	public static SocketConsole createLogFileConsole(CodewindApplication app, ProjectLogInfo logInfo) throws Exception {
 		String consoleName;
 		consoleName = NLS.bind(Messages.LogFileConsoleName, app.name, logInfo.logName);
 		SocketConsole console = new SocketConsole(consoleName, logInfo, app);

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/console/SocketConsole.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/console/SocketConsole.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -31,7 +31,7 @@ public class SocketConsole extends IOConsole {
 	private boolean isInitialized = false;
 	private boolean showOnUpdate = false;
 
-	public SocketConsole(String consoleName, ProjectLogInfo logInfo, CodewindApplication app) {
+	public SocketConsole(String consoleName, ProjectLogInfo logInfo, CodewindApplication app) throws Exception {
 		super(consoleName, CodewindConsoleFactory.CODEWIND_CONSOLE_TYPE,
 				CodewindCorePlugin.getIcon(CodewindCorePlugin.DEFAULT_ICON_PATH),
 				true);
@@ -42,12 +42,8 @@ public class SocketConsole extends IOConsole {
 		this.socket = app.connection.getSocket();
 		socket.registerSocketConsole(this);
 
-		try {
-			this.outputStream.write(Messages.LogFileInitialMsg);
-			app.connection.requestEnableLogStream(app, logInfo);
-		} catch (Exception e) {
-			Logger.logError("Error opening console output stream for: " + this.getName(), e);
-		}
+		this.outputStream.write(Messages.LogFileInitialMsg);
+		app.connection.requestEnableLogStream(app, logInfo);
 	}
 
 	public void update(String contents, boolean reset) throws IOException {

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/HideAllLogsAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/HideAllLogsAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -15,8 +15,14 @@ import org.eclipse.codewind.core.internal.CodewindEclipseApplication;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.console.ProjectLogInfo;
 import org.eclipse.codewind.core.internal.console.SocketConsole;
+import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.messages.Messages;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.action.Action;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.ui.console.ConsolePlugin;
 import org.eclipse.ui.console.IConsole;
 import org.eclipse.ui.console.IConsoleManager;
@@ -62,13 +68,25 @@ public class HideAllLogsAction extends Action {
         }
         
         // Remove any existing consoles for this app
-        for (ProjectLogInfo logInfo : app.getLogInfos()) {
-        	SocketConsole console = app.getConsole(logInfo);
-    		if (console != null) {
-				IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
-				consoleManager.removeConsoles(new IConsole[] { console });
-				app.removeConsole(console);
-    		}
-    	}
+        Job job = new Job(NLS.bind(Messages.HideAllLogFilesJobLabel, app.name)) {
+			@Override
+			protected IStatus run(IProgressMonitor monitor) {
+				try {
+					for (ProjectLogInfo logInfo : app.getLogInfos()) {
+						SocketConsole console = app.getConsole(logInfo);
+						if (console != null) {
+							IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
+							consoleManager.removeConsoles(new IConsole[] { console });
+							app.removeConsole(console);
+						}
+					}
+					return Status.OK_STATUS;
+				} catch (Exception e) {
+					Logger.logError("An error occurred closing the log files for: " + app.name + ", with id: " + app.projectID, e); //$NON-NLS-1$ //$NON-NLS-2$
+					return new Status(IStatus.ERROR, CodewindUIPlugin.PLUGIN_ID, NLS.bind(Messages.HideAllLogFilesError, app.name), e);
+				}
+			}
+		};
+		job.schedule();
     }
 }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/LogFileAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/LogFileAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -16,15 +16,22 @@ import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.console.CodewindConsoleFactory;
 import org.eclipse.codewind.core.internal.console.ProjectLogInfo;
 import org.eclipse.codewind.core.internal.console.SocketConsole;
+import org.eclipse.codewind.ui.CodewindUIPlugin;
+import org.eclipse.codewind.ui.internal.messages.Messages;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IAction;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.ui.console.ConsolePlugin;
 import org.eclipse.ui.console.IConsole;
 import org.eclipse.ui.console.IConsoleManager;
 import org.eclipse.ui.navigator.ICommonViewerSite;
 
 /**
- * Action for showing a log file for a Codewind application
+ * Action for showing/hiding a log file for a Codewind application
  */
 public class LogFileAction extends Action {
 	
@@ -46,17 +53,45 @@ public class LogFileAction extends Action {
 			return;
 		}
 
-        if (isChecked()) {
-    		SocketConsole console = CodewindConsoleFactory.createLogFileConsole(app, logInfo);
-			ConsolePlugin.getDefault().getConsoleManager().showConsoleView(console);
-			app.addConsole(console);
-        } else {
-        	SocketConsole console = app.getConsole(logInfo);
-        	if (console != null) {
-				IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
-				consoleManager.removeConsoles(new IConsole[] { console });
-				app.removeConsole(console);
-        	}
-        }
+        try {
+			if (isChecked()) {
+				Job job = new Job(NLS.bind(Messages.ShowLogFileJobLabel, new String[] {app.name, logInfo.logName})) {
+					@Override
+					protected IStatus run(IProgressMonitor monitor) {
+						try {
+							SocketConsole console = CodewindConsoleFactory.createLogFileConsole(app, logInfo);
+							ConsolePlugin.getDefault().getConsoleManager().showConsoleView(console);
+							app.addConsole(console);
+							return Status.OK_STATUS;
+						} catch (Exception e) {
+							Logger.logError("An error occurred opening the " + logInfo.logName + " log file for: " + app.name + ", with id: " + app.projectID, e); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+							return new Status(IStatus.ERROR, CodewindUIPlugin.PLUGIN_ID, NLS.bind(Messages.ShowLogFileError, new String[] {logInfo.logName, app.name}), e);
+						}
+					}
+				};
+				job.schedule();
+			} else {
+				Job job = new Job(NLS.bind(Messages.HideLogFileJobLabel, new String[] {app.name, logInfo.logName})) {
+					@Override
+					protected IStatus run(IProgressMonitor monitor) {
+						try {
+							SocketConsole console = app.getConsole(logInfo);
+							if (console != null) {
+								IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
+								consoleManager.removeConsoles(new IConsole[] { console });
+								app.removeConsole(console);
+							}
+							return Status.OK_STATUS;
+						} catch (Exception e) {
+							Logger.logError("An error occurred closing the " + logInfo.logName + " log file for: " + app.name + ", with id: " + app.projectID, e); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+							return new Status(IStatus.ERROR, CodewindUIPlugin.PLUGIN_ID, NLS.bind(Messages.HideLogFileError, new String[] {logInfo.logName, app.name}), e);
+						}
+					}
+				};
+				job.schedule();
+			}
+		} catch (Exception e) {
+			// Ignore
+		}
     }
 }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/ShowAllLogsAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/ShowAllLogsAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -16,8 +16,14 @@ import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.console.CodewindConsoleFactory;
 import org.eclipse.codewind.core.internal.console.ProjectLogInfo;
 import org.eclipse.codewind.core.internal.console.SocketConsole;
+import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.messages.Messages;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.action.Action;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.ui.console.ConsolePlugin;
 
 /**
@@ -61,12 +67,24 @@ public class ShowAllLogsAction extends Action {
         }
         
         // Create consoles for any log files that don't have one yet
-        for (ProjectLogInfo logInfo : app.getLogInfos()) {
-    		if (app.getConsole(logInfo) == null) {
-    			SocketConsole console = CodewindConsoleFactory.createLogFileConsole(app, logInfo);
-    			ConsolePlugin.getDefault().getConsoleManager().showConsoleView(console);
-    			app.addConsole(console);
-    		}
-    	}
+        Job job = new Job(NLS.bind(Messages.ShowAllLogFilesJobLabel, app.name)) {
+			@Override
+			protected IStatus run(IProgressMonitor monitor) {
+				try {
+					for (ProjectLogInfo logInfo : app.getLogInfos()) {
+						if (app.getConsole(logInfo) == null) {
+							SocketConsole console = CodewindConsoleFactory.createLogFileConsole(app, logInfo);
+							ConsolePlugin.getDefault().getConsoleManager().showConsoleView(console);
+							app.addConsole(console);
+						}
+					}
+					return Status.OK_STATUS;
+				} catch (Exception e) {
+					Logger.logError("An error occurred opening the log files for: " + app.name + ", with id: " + app.projectID, e); //$NON-NLS-1$ //$NON-NLS-2$
+					return new Status(IStatus.ERROR, CodewindUIPlugin.PLUGIN_ID, NLS.bind(Messages.ShowAllLogFilesError, app.name), e);
+				}
+			}
+		};
+		job.schedule();
     }
 }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -257,8 +257,16 @@ public class Messages extends NLS {
 	public static String EditConnectionActionLabel;
 	
 	public static String ShowLogFilesMenu;
+	public static String ShowLogFileJobLabel;
+	public static String ShowLogFileError;
+	public static String HideLogFileJobLabel;
+	public static String HideLogFileError;
 	public static String ShowAllLogFilesAction;
+	public static String ShowAllLogFilesJobLabel;
+	public static String ShowAllLogFilesError;
 	public static String HideAllLogFilesAction;
+	public static String HideAllLogFilesJobLabel;
+	public static String HideAllLogFilesError;
 	public static String ErrorOnShowLogFileDialogTitle;
 	public static String ShowOnContentChangeAction;
 	

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -251,8 +251,16 @@ RemoveConnectionActionLabel=&Remove
 EditConnectionActionLabel=&Edit...
 
 ShowLogFilesMenu=&Show Log Files
+ShowLogFileJobLabel=Opening {0} log file: {1}
+ShowLogFileError=An error occurred while opening the {0} log file for: {1}
+HideLogFileJobLabel=Closing {0} log file: {1}
+HideLogFileError=An error occurred while closing the {0} log file for: {1}
 ShowAllLogFilesAction=&Show All
+ShowAllLogFilesJobLabel=Opening log files for: {0}
+ShowAllLogFilesError=An error occurred while opening the log files for {0}.
 HideAllLogFilesAction=&Hide All
+HideAllLogFilesJobLabel=Closing log files for: {0}
+HideAllLogFilesError=An error occurred while closing the log files for {0}.
 ErrorOnShowLogFileDialogTitle=An error occurred while opening or closing the stream for the log file.
 ShowOnContentChangeAction=Show on Content Change
 


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/1934

Change all of the log file actions to run inside jobs so they don't hold up the IDE.