### PR TITLE
CW Issue #1952 - Java Filewatcher is not correctly rate limiting its PUT requests on failure #1952

### DIFF
--- a/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/Filewatcher.java
+++ b/dev/org.eclipse.codewind.filewatchers.core/src/org/eclipse/codewind/filewatchers/core/Filewatcher.java
@@ -772,6 +772,9 @@ public class Filewatcher {
 					log.logError("Unable to inform server of watch status for '" + ptw.getProjectWatchStateId() + "'",
 							t);
 					success = false;
+				}
+
+				if (!success) {
 					backoffUtil.sleepIgnoreInterrupt();
 					backoffUtil.failIncrease();
 				}


### PR DESCRIPTION
Parent issue: https://github.com/eclipse/codewind/issues/1952