### PR TITLE
CW Issue #1746: derigister as push if push registry is removed

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
@@ -804,6 +804,18 @@ public class CodewindConnection {
 		return requestGetPushRegistry() != null;
 	}
 	
+	public void requestDeletePushRegistry(String address) throws IOException, JSONException {
+		final URI uri = baseUri.resolve(CoreConstants.APIPATH_BASE + "/" + CoreConstants.APIPATH_IMAGEPUSHREGISTRY);
+		JSONObject payload = new JSONObject();
+		payload.put(CoreConstants.KEY_ADDRESS, address);
+		
+		HttpResult result = HttpUtil.delete(uri, getAuthToken(false), payload);
+		if (hasAuthFailure(result)) {
+			result = HttpUtil.delete(uri, getAuthToken(true), payload);
+		}
+		checkResult(result, uri, false);
+	}
+	
 	public void requestInjectMetrics(String projectID, boolean enable) throws IOException, JSONException {
 		String endpoint = CoreConstants.APIPATH_PROJECT_LIST + "/"	//$NON-NLS-1$
 				+ projectID + "/"	//$NON-NLS-1$

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/RegistryManagementComposite.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/RegistryManagementComposite.java
@@ -306,6 +306,9 @@ public class RegistryManagementComposite extends Composite {
 			if (entry == null) {
 				// Remove the registry
 				try {
+					if (pushReg != null && pushReg.getAddress().equals(info.getAddress())) {
+						connection.requestDeletePushRegistry(info.getAddress());
+					}
 					connection.requestRemoveRegistry(info.getAddress(), info.getUsername());
 				} catch (Exception e) {
 					Logger.logError("Failed to remove registry: " + info.getAddress(), e); //$NON-NLS-1$


### PR DESCRIPTION
If the user has selected to remove the push registry then it also needs to be deregistered as the image push registry using the new DELETE api/v1/imagepushregistry endpoint.