### PR TITLE
Enable metrics injection for Docker Java projects

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
@@ -546,7 +546,9 @@ public class CodewindApplication {
 				ProjectType.TYPE_SPRING,
 				ProjectType.TYPE_NODEJS
 		);
-		return projectTypesWithMetricInjection.contains(projectType);
+		return projectTypesWithMetricInjection.contains(projectType) ||
+				(ProjectType.TYPE_DOCKER.equals(projectType) &&
+				 ProjectLanguage.LANGUAGE_JAVA.equals(projectLanguage));
 	}
 
 	@Override


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

This PR fixes the front end for eclipse/codewind#1509 in Eclipse.

OpenLiberty projects are currently defined as type Docker with language Java. I've raised eclipse/codewind#1960 to try and improve that.

Please feel free to comment on anything I've missed!