### PR TITLE
CW Issue #1698: Remove extra space after sections in app overview page

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
@@ -324,7 +324,7 @@ public class ApplicationOverviewEditorPart extends EditorPart {
 		private final StringEntry locationEntry;
 		
 		public ProjectInfoSection(Composite parent, FormToolkit toolkit, int hSpan, int vSpan) {
-			Section section = toolkit.createSection(parent, ExpandableComposite.TWISTIE | ExpandableComposite.TITLE_BAR | Section.DESCRIPTION);
+			Section section = toolkit.createSection(parent, ExpandableComposite.TWISTIE | ExpandableComposite.TITLE_BAR);
 	        section.setText(Messages.AppOverviewEditorProjectInfoSection);
 	        section.setLayoutData(new GridData(SWT.FILL,SWT.FILL, true, false, hSpan, vSpan));
 	        section.setExpanded(true);
@@ -364,7 +364,7 @@ public class ApplicationOverviewEditorPart extends EditorPart {
 		private final StringEntry lastImageBuildEntry;
 		
 		public ProjectStatusSection(Composite parent, FormToolkit toolkit, int hSpan, int vSpan) {
-			Section section = toolkit.createSection(parent, ExpandableComposite.TWISTIE | ExpandableComposite.TITLE_BAR | Section.DESCRIPTION);
+			Section section = toolkit.createSection(parent, ExpandableComposite.TWISTIE | ExpandableComposite.TITLE_BAR);
 	        section.setText(Messages.AppOverviewEditorProjectStatusSection);
 	        section.setLayoutData(new GridData(SWT.FILL,SWT.FILL, true, false, hSpan, vSpan));
 	        section.setExpanded(true);
@@ -421,7 +421,7 @@ public class ApplicationOverviewEditorPart extends EditorPart {
 		private final Button infoButton;
 		
 		public AppInfoSection(Composite parent, FormToolkit toolkit, int hSpan, int vSpan) {
-			Section section = toolkit.createSection(parent, ExpandableComposite.TWISTIE | ExpandableComposite.TITLE_BAR | Section.DESCRIPTION);
+			Section section = toolkit.createSection(parent, ExpandableComposite.TWISTIE | ExpandableComposite.TITLE_BAR);
 	        section.setText(Messages.AppOverviewEditorAppInfoSection);
 	        section.setLayoutData(new GridData(SWT.FILL,SWT.FILL, true, false, hSpan, vSpan));
 	        section.setExpanded(true);


### PR DESCRIPTION
Remove DESCRIPTION style so that the extra space for it after the section title does not get created.