### PR TITLE
CW Issue #1695: Allow the user to select the connection when binding a project

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/BindAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/BindAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -15,11 +15,9 @@ import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.messages.Messages;
-import org.eclipse.codewind.ui.internal.views.ViewHelper;
 import org.eclipse.codewind.ui.internal.wizards.BindProjectWizard;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.jface.window.Window;
 import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.actions.SelectionProviderAction;
@@ -62,12 +60,7 @@ public class BindAction extends SelectionProviderAction {
 		try {
 			BindProjectWizard wizard = new BindProjectWizard(connection);
 			WizardDialog dialog = new WizardDialog(Display.getDefault().getActiveShell(), wizard);
-			if (dialog.open() == Window.CANCEL) {
-				return;
-			}
-			ViewHelper.openCodewindExplorerView();
-			ViewHelper.refreshCodewindExplorerView(null);
-			ViewHelper.expandConnection(connection);
+			dialog.open();
 		} catch (Exception e) {
 			Logger.logError("An error occurred running the bind action on connection: " + connection.getBaseURI(), e); //$NON-NLS-1$
 		}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/BindProjectAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/BindProjectAction.java
@@ -11,109 +11,34 @@
 
 package org.eclipse.codewind.ui.internal.actions;
 
-import java.lang.reflect.InvocationTargetException;
-import java.util.concurrent.TimeoutException;
-
-import org.eclipse.codewind.core.internal.CodewindManager;
-import org.eclipse.codewind.core.internal.CodewindManager.InstallerStatus;
-import org.eclipse.codewind.core.internal.CoreUtil;
 import org.eclipse.codewind.core.internal.Logger;
-import org.eclipse.codewind.core.internal.ProcessHelper.ProcessResult;
-import org.eclipse.codewind.core.internal.cli.InstallStatus;
-import org.eclipse.codewind.core.internal.cli.InstallUtil;
-import org.eclipse.codewind.core.internal.connection.CodewindConnection;
-import org.eclipse.codewind.core.internal.connection.CodewindConnectionManager;
-import org.eclipse.codewind.ui.internal.messages.Messages;
-import org.eclipse.codewind.ui.internal.views.ViewHelper;
 import org.eclipse.codewind.ui.internal.wizards.BindProjectWizard;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.action.IAction;
-import org.eclipse.jface.dialogs.ProgressMonitorDialog;
-import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.jface.window.Window;
 import org.eclipse.jface.wizard.WizardDialog;
-import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IObjectActionDelegate;
 import org.eclipse.ui.IWorkbenchPart;
 
 public class BindProjectAction implements IObjectActionDelegate {
 	
-	private IWorkbenchPart part;
 	private IProject project;
 
 	@Override
 	public void run(IAction action) {
-		CodewindConnection connection = null;
-
 		if (project == null) {
 			// Should not happen
 			Logger.logError("BindProjectAction ran but no project was selected"); //$NON-NLS-1$
 			return;
 		}
 
-		// If the installer is currently running, show a dialog to the user
-		final InstallerStatus installerStatus = CodewindManager.getManager().getInstallerStatus();
-		if (installerStatus != null) {
-			Display.getDefault().asyncExec(new Runnable() {
-				@Override
-				public void run() {
-					CodewindInstall.installerActiveDialog(installerStatus);
-				}
-			});
-			return;
-		}
-		
-		if (CodewindManager.getManager().getInstallStatus().isInstalled()) {
-			connection = setupConnection();
-		} else {
-			CodewindInstall.codewindInstallerDialog(project);
-			return;
-		}
-
-		if (connection == null || !connection.isConnected()) {
-			CoreUtil.openDialog(true, Messages.BindProjectErrorTitle, Messages.BindProjectConnectionError);
-			return;
-		}
-		
-		String projectError = getProjectError(connection, project);
-		if (projectError != null) {
-			CoreUtil.openDialog(true, Messages.BindProjectErrorTitle, projectError);
-			// If connection is new (not already registered), then close it
-			if (CodewindConnectionManager.getActiveConnection(connection.getBaseURI().toString()) == null) {
-				connection.disconnect();
-			}
-			return;
-		}
-		
-		BindProjectWizard wizard = new BindProjectWizard(connection, project);
+		BindProjectWizard wizard = new BindProjectWizard(null, project);
 		WizardDialog dialog = new WizardDialog(Display.getDefault().getActiveShell(), wizard);
-		if (dialog.open() == Window.CANCEL) {
-			// If connection is new (not already registered), then close it
-			if (CodewindConnectionManager.getActiveConnection(connection.getBaseURI().toString()) == null) {
-				connection.disconnect();
-			}
-		} else {
-			// Add the connection if not already registered
-			if (CodewindConnectionManager.getActiveConnection(connection.getBaseURI().toString()) == null) {
-				CodewindConnectionManager.add(connection);
-			}
-			ViewHelper.openCodewindExplorerView();
-			ViewHelper.refreshCodewindExplorerView(null);
-			ViewHelper.expandConnection(connection);
-		}
+		dialog.open();
 	}
 	
-	private String getProjectError(CodewindConnection connection, IProject project) {
-		if (connection.getAppByLocation(project.getLocation()) != null) {
-			return NLS.bind(Messages.BindProjectAlreadyExistsError,  project.getName());
-		}
-		return null;
-	}
-
 	@Override
 	public void selectionChanged(IAction action, ISelection selection) {
         if (!(selection instanceof IStructuredSelection)) {
@@ -136,60 +61,6 @@ public class BindProjectAction implements IObjectActionDelegate {
 
 	@Override
 	public void setActivePart(IAction action, IWorkbenchPart part) {
-		this.part = part;
-	}
-	
-	
-	private CodewindConnection setupConnection() {
-		final CodewindManager manager = CodewindManager.getManager();
-		CodewindConnection connection = CodewindConnectionManager.getLocalConnection();
-		if (connection != null && connection.isConnected()) {
-			return connection;
-		}
-		InstallStatus status = manager.getInstallStatus();
-		if (status.isStarted()) {
-			if (!connection.isConnected()) {
-				// This should not happen since the connection should be established as part of the start action
-				Logger.logError("Local Codewind is started but the connection has not been established or is down");
-				return null;
-			}
-			return connection;
-		}
-		if (!status.isInstalled()) {
-			Logger.logError("In BindProjectAction run method and Codewind is not installed or has unknown status."); //$NON-NLS-1$
-			return null;
-		}
-		
-		IRunnableWithProgress runnable = new IRunnableWithProgress() {
-			@Override
-			public void run(IProgressMonitor monitor) throws InvocationTargetException {
-				try {
-					ProcessResult result = InstallUtil.startCodewind(status.getVersion(), monitor);
-					if (result.getExitValue() != 0) {
-						Logger.logError("Installer start failed with return code: " + result.getExitValue() + ", output: " + result.getOutput() + ", error: " + result.getError()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-						String errorText = result.getError() != null && !result.getError().isEmpty() ? result.getError() : result.getOutput();
-						throw new InvocationTargetException(null, "There was a problem trying to start Codewind: " + errorText); //$NON-NLS-1$
-					}
-					CodewindConnection connection = CodewindConnectionManager.getLocalConnection();
-					ViewHelper.refreshCodewindExplorerView(connection);
-				} catch (TimeoutException e) {
-					throw new InvocationTargetException(e, "Codewind did not start in the expected time: " + e.getMessage()); //$NON-NLS-1$
-				} catch (Exception e) {
-					throw new InvocationTargetException(e, "An error occurred trying to start Codewind: " + e.getMessage()); //$NON-NLS-1$
-				}
-			}
-		};
-		try {
-			ProgressMonitorDialog dialog = new ProgressMonitorDialog(part.getSite().getShell());
-			dialog.run(true, true, runnable);
-		} catch (InvocationTargetException e) {
-			Logger.logError("An error occurred trying to start Codewind", e); //$NON-NLS-1$
-			return null;
-		} catch (InterruptedException e) {
-			Logger.logError("Codewind start was interrupted", e); //$NON-NLS-1$
-			return null;
-		}
-
-		return CodewindConnectionManager.getLocalConnection();
+		// empty
 	}
 }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -174,6 +174,11 @@ public class Messages extends NLS {
 	public static String BindProjectWizardJobLabel;
 	public static String BindProjectWizardError;
 	
+	public static String SelectConnectionPageName;
+	public static String SelectConnectionPageTitle;
+	public static String SelectConnectionPageDescription;
+	public static String SelectConnectionPageNoSelectionMsg;
+	
 	public static String MoveProjectJobLabel;
 	public static String MoveProjectError;
 	

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -124,14 +124,19 @@ UnbindActionMultipleJobTitle=Removing {0} projects
 UnbindActionError=An error occurred trying to remove the {0} project from Codewind.
 
 BindProjectErrorTitle=Add Existing Project Error
-BindProjectConnectionError=Adding the project failed because a connection to Codewind could not be established. Check workspace logs for details.
-BindProjectAlreadyExistsError=A Codewind project with the name {0} already exists.
+BindProjectConnectionError=Adding the project failed because a connection to {0} could not be established. Check workspace logs for details.
+BindProjectAlreadyExistsError=A project with the name {0} already exists on the {1} connection.
 
 BindProjectWizardTitle=Add Existing Project to Codewind
 BindProjectWizardRemoveTask=Removing existing deployments
 BindProjectWizardDisableTask=Disabling existing deployments
 BindProjectWizardJobLabel=Adding project to {0}: {1}
 BindProjectWizardError=An error occurred trying to add the {0} project to Codewind.
+
+SelectConnectionPageName=Select Connection
+SelectConnectionPageTitle=Select a Connection
+SelectConnectionPageDescription=Select a connection for the project.
+SelectConnectionPageNoSelectionMsg=Select a connection from the list.
 
 MoveProjectJobLabel=Moving project to {0}: {1}
 MoveProjectError=An error occurred while moving the {0} project from {1} to {2}.

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorLabelProvider.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorLabelProvider.java
@@ -247,9 +247,13 @@ public class CodewindNavigatorLabelProvider extends LabelProvider implements ISt
 		}
 		return styledString;
 	}
-
+	
 	@Override
 	public Image getImage(Object element) {
+		return getCodewindImage(element);
+	}
+
+	public static Image getCodewindImage(Object element) {
 		if (element instanceof CodewindManager) {
 			return CodewindUIPlugin.getImage(CodewindUIPlugin.CODEWIND_ICON);
 		} else if (element instanceof LocalConnection) {

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ConnectionSelectionPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ConnectionSelectionPage.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *	 IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.codewind.ui.internal.wizards;
+
+import java.util.List;
+
+import org.eclipse.codewind.core.internal.connection.CodewindConnection;
+import org.eclipse.codewind.core.internal.connection.LocalConnection;
+import org.eclipse.codewind.core.internal.connection.RemoteConnection;
+import org.eclipse.codewind.ui.internal.messages.Messages;
+import org.eclipse.codewind.ui.internal.views.CodewindNavigatorLabelProvider;
+import org.eclipse.jface.viewers.ArrayContentProvider;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.wizard.WizardPage;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+
+public class ConnectionSelectionPage extends WizardPage {
+	
+	private List<CodewindConnection> connections;
+	private CodewindConnection connection;
+
+	protected ConnectionSelectionPage(List<CodewindConnection> connections) {
+		super(Messages.SelectConnectionPageName);
+		setTitle(Messages.SelectConnectionPageTitle);
+		setDescription(Messages.SelectConnectionPageDescription);
+		this.connections = connections;
+	}
+
+	@Override
+	public void createControl(Composite parent) {
+		Composite composite = new Composite(parent, SWT.NONE);
+		GridLayout layout = new GridLayout();
+		layout.numColumns = 1;
+		layout.horizontalSpacing = 5;
+		layout.verticalSpacing = 7;
+		composite.setLayout(layout);
+		GridData data = new GridData(GridData.FILL_HORIZONTAL);
+		composite.setLayoutData(data);
+		
+		TableViewer connViewer = new TableViewer(composite, SWT.BORDER | SWT.SINGLE | SWT.V_SCROLL);
+		connViewer.setContentProvider(ArrayContentProvider.getInstance());
+		connViewer.setLabelProvider(new ConnLabelProvider());
+		connViewer.setInput(connections);
+		connViewer.getTable().setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, true));
+		connViewer.addSelectionChangedListener((SelectionChangedEvent event) -> {
+			connection = (CodewindConnection)connViewer.getStructuredSelection().getFirstElement();
+			validate();
+		});
+
+		setControl(composite);
+	}
+	
+	private void validate() {
+		String errorMsg = null;
+		if (connection == null) {
+			errorMsg = Messages.SelectConnectionPageNoSelectionMsg;
+		}
+		setErrorMessage(errorMsg);
+		getWizard().getContainer().updateButtons();
+	}
+
+	@Override
+	public boolean canFlipToNextPage() {
+		return canFinish();
+	}
+	
+	public boolean isActivePage() {
+		return isCurrentPage();
+	}
+
+	public boolean canFinish() {
+		return connection != null;
+	}
+	
+	public CodewindConnection getConnection() {
+		return connection;
+	}
+	
+	private class ConnLabelProvider extends LabelProvider {
+		@Override
+		public Image getImage(Object element) {
+			return CodewindNavigatorLabelProvider.getCodewindImage(element);
+		}
+
+		@Override
+		public String getText(Object element) {
+			if (element instanceof LocalConnection) {
+				return ((CodewindConnection)element).getName();
+			} else if (element instanceof RemoteConnection) {
+				return ((CodewindConnection)element).getName() + " (" + ((CodewindConnection)element).getBaseURI() + ")";
+			}
+			return null;
+		}
+	}
+	
+}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectSelectionPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectSelectionPage.java
@@ -36,7 +36,6 @@ import org.eclipse.jface.viewers.ICheckStateListener;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.jface.window.Window;
-import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
@@ -58,7 +57,6 @@ import org.eclipse.ui.model.WorkbenchLabelProvider;
 
 public class ProjectSelectionPage extends WizardPage {
 	
-	private final BindProjectWizard wizard;
 	private SearchPattern pattern = new SearchPattern(SearchPattern.RULE_PATTERN_MATCH | SearchPattern.RULE_PREFIX_MATCH | SearchPattern.RULE_BLANK_MATCH);
 	private final CodewindConnection connection;
 	private Button workspaceProject;
@@ -71,12 +69,11 @@ public class ProjectSelectionPage extends WizardPage {
 	private String projectPath = null;
 	private boolean hasValidProjects = false;
 
-	protected ProjectSelectionPage(BindProjectWizard wizard, CodewindConnection connection) {
+	protected ProjectSelectionPage(CodewindConnection connection) {
 		super(Messages.SelectProjectPageName);
 		setTitle(Messages.SelectProjectPageTitle);
 		setDescription(Messages.SelectProjectPageDescription);
 		pattern.setPattern("*");
-		this.wizard = wizard;
 		this.connection = connection;
 		hasValidProjects = hasValidProjects();
 	}
@@ -387,11 +384,8 @@ public class ProjectSelectionPage extends WizardPage {
 		return canFinish();
 	}
 
-	@Override
-	public IWizardPage getNextPage() {
-		// Set the project so the next page has it.
-		wizard.setProject(project, getProjectPath());
-		return super.getNextPage();
+	public boolean isActivePage() {
+		return isCurrentPage();
 	}
 
 	public boolean canFinish() {

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectTypeSelectionPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectTypeSelectionPage.java
@@ -195,9 +195,6 @@ public class ProjectTypeSelectionPage extends WizardPage {
 		subtypeLabel.setVisible(false);
 		subtypeViewer.getTable().setVisible(false);
 
-		initTypeMap();
-		updateTables(true);
-
 		typeViewer.getTable().setFocus();
 		setControl(composite);
 	}
@@ -254,18 +251,20 @@ public class ProjectTypeSelectionPage extends WizardPage {
 		}
 	}
 	
-	public void setProjectInfo(ProjectInfo projectInfo) {
+	public void initPage(CodewindConnection connection, ProjectInfo projectInfo) {
+		this.connection = connection;
+		initTypeMap();
 		this.projectInfo = projectInfo;
 		if (projectInfo == null) {
 			projectTypeInfo = null;
 			projectSubtypeInfo = null;
-		} else if (typeMap != null) {
+		} else {
 			projectTypeInfo = typeMap.get(projectInfo.type.getId());
 			projectSubtypeInfo = projectTypeInfo.new ProjectSubtypeInfo(projectInfo.language.getId());
 		}
 		updateTables(true);
 	}
-
+	
 	public void initTypeMap() {
 		IRunnableWithProgress runnable = new IRunnableWithProgress() {
 			@Override
@@ -285,11 +284,7 @@ public class ProjectTypeSelectionPage extends WizardPage {
 			return;
 		}
 	}
-	
-	public CodewindConnection getConnection() {
-		return connection;
-	}
-	
+
 	public ProjectTypeInfo getType() {
 		return projectTypeInfo;
 	}


### PR DESCRIPTION
If the Codewind > Add Project context menu item is used on a project the user should be able to select the connection they want if there is more than one.

- Added a connection selection page to the start of the wizard if there is more than one connection
- Moved the install status checking to BindProjectWizard so it can be done after the user selects the connection
- Added code to check if the remote connection is connected and if not connect when the user clicks next
- Verified that the new connection selection page is accessible