### PR TITLE
CW Issue #1698: Cleanup items for application overview page

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
@@ -383,17 +383,17 @@ public class ApplicationOverviewEditorPart extends EditorPart {
 	        
 	        autoBuildEntry = new StringEntry(composite, Messages.AppOverviewEditorAutoBuildEntry);
 	        injectMetricsEntry = new StringEntry(composite, Messages.AppOverviewEditorInjectMetricsEntry);
-	        appStatusEntry = new StringEntry(composite, "Application Status:");
-	        buildStatusEntry = new StringEntry(composite, "Build Status:");
+	        appStatusEntry = new StringEntry(composite, Messages.AppOverviewEditorAppStatusEntry);
+	        buildStatusEntry = new StringEntry(composite, Messages.AppOverviewEditorBuildStatusEntry);
 	        lastImageBuildEntry = new StringEntry(composite, Messages.AppOverviewEditorLastImageBuildEntry);
 	        lastBuildEntry = new StringEntry(composite, Messages.AppOverviewEditorLastBuildEntry);
 		}
 		
 		public void update(CodewindApplication app) {
-			autoBuildEntry.setValue(app.isAutoBuild() ? Messages.AppOverviewEditorAutoBuildOn : Messages.AppOverviewEditorAutoBuildOff, app.isAvailable());
-			injectMetricsEntry.setValue(metricsInjectionState(app.canInjectMetrics(), app.isInjectMetrics()), app.isAvailable());
-			appStatusEntry.setValue(app.getAppStatus().getDisplayString(app.getStartMode()), app.isAvailable());
-			buildStatusEntry.setValue(app.getBuildStatus().getDisplayString(), app.isAvailable());
+			autoBuildEntry.setValue(app.isAutoBuild() ? Messages.AppOverviewEditorAutoBuildOn : Messages.AppOverviewEditorAutoBuildOff, true);
+			injectMetricsEntry.setValue(metricsInjectionState(app.canInjectMetrics(), app.isInjectMetrics()), true);
+			appStatusEntry.setValue(app.isAvailable() ? app.getAppStatus().getDisplayString(app.getStartMode()) : Messages.AppOverviewEditorStatusDisabled, true);
+			buildStatusEntry.setValue(app.isAvailable() ? app.getBuildStatus().getDisplayString() : null, true);
 			long lastImageBuild = app.getLastImageBuild();
 			String lastImageBuildStr = Messages.AppOverviewEditorImageNeverBuilt;
 			if (lastImageBuild > 0) {

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -417,6 +417,8 @@ public class Messages extends NLS {
 	public static String AppOverviewEditorOpenSettingsNotFound;
 	public static String AppOverviewEditorNoConnection;
 	public static String AppOverviewEditorNoApplication;
+	public static String AppOverviewEditorAppStatusEntry;
+	public static String AppOverviewEditorBuildStatusEntry;
 	
 	public static String StopAllDialog_Title;
 	public static String StopAllDialog_Message;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -411,6 +411,8 @@ AppOverviewEditorInjectMetricsEntry=Inject Appmetrics:
 AppOverviewEditorInjectMetricsOn=On
 AppOverviewEditorInjectMetricsOff=Off
 AppOverviewEditorInjectMetricsUnavailable=Unavailable for this language
+AppOverviewEditorAppStatusEntry=Application Status:
+AppOverviewEditorBuildStatusEntry=Build Status:
 
 StopAllDialog_Title=Stopping Codewind
 StopAllDialog_Message=Do you want to stop your application containers as well?


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/1698

- Fixed a problem where some entries were hidden if the application is disabled instead of showing a value of "Not available"
- Created entries in the Messages files for a couple of labels