### PR TITLE
CW Issue #1931: Update the appsody release to 0.5.7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
     }
 
     parameters {
-        string(name: "APPSODY_VERSION", defaultValue: "0.5.4", description: "Appsody executable version to download")
+        string(name: "APPSODY_VERSION", defaultValue: "0.5.7", description: "Appsody executable version to download")
     }
 
     stages {


### PR DESCRIPTION
Update the appsody release to 0.5.7.  See https://github.com/eclipse/codewind/issues/1931.