### PR TITLE
CW Issue #2033: Update links to documentation

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/UIConstants.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/UIConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@ public class UIConstants {
 	public static final String 
 		DOC_BASE_URL = "https://www.eclipse.org/codewind",
 		CWSETTINGS_INFO_URL = DOC_BASE_URL + "/mdteclipsemanagingprojects.html",
-		TEMPLATES_INFO_URL = DOC_BASE_URL + "/mdteclipseworkingwithtemplates.html",
+		TEMPLATES_INFO_URL = DOC_BASE_URL + "/workingwithtemplates.html",
 		REGISTRY_INFO_URL = DOC_BASE_URL + "/image-registry-credentials.html",
-		REMOTE_SETUP_URL =  DOC_BASE_URL +"/remoteconnectionui.html";
+		REMOTE_SETUP_URL =  DOC_BASE_URL +"/remotedeploy-eclipse.html";
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/2033

The documentation has been re-organized so the links in the IDE need to be updated.  See https://github.com/eclipse/codewind/issues/2033 for more information.