### PR TITLE
Issue #571: Check application status after changing auto build mode

### DIFF
--- a/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/BaseAutoBuildTest.java
+++ b/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/BaseAutoBuildTest.java
@@ -40,6 +40,10 @@ public abstract class BaseAutoBuildTest extends BaseTest {
     @Test
     public void test03_disableAutoBuild() throws Exception {
     	setAutoBuild(false);
+    	// Some project types need to restart when auto build changes (node.js)
+    	CodewindApplication app = connection.getAppByName(projectName);
+    	CodewindUtil.waitForAppState(app, AppStatus.STOPPING, 5, 1);
+    	assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppStatus.STARTED, 120, 1));
     }
     
     @Test
@@ -65,6 +69,10 @@ public abstract class BaseAutoBuildTest extends BaseTest {
     @Test
     public void test05_enableAutoBuild() throws Exception {
     	setAutoBuild(true);
+    	// Some project types need to restart when auto build changes (node.js)
+    	CodewindApplication app = connection.getAppByName(projectName);
+    	CodewindUtil.waitForAppState(app, AppStatus.STOPPING, 5, 1);
+    	assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppStatus.STARTED, 120, 1));
     }
     
     @Test

--- a/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/util/CodewindUtil.java
+++ b/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/util/CodewindUtil.java
@@ -12,6 +12,7 @@
 package org.eclipse.codewind.test.util;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 import org.eclipse.codewind.core.internal.CodewindApplication;
 import org.eclipse.codewind.core.internal.cli.ProjectUtil;
@@ -76,23 +77,21 @@ public class CodewindUtil {
 	}
 	
 	public static boolean waitForAppState(CodewindApplication app, AppStatus status, long timeout, long interval) {
-		TestUtil.wait(new Condition() {
-			@Override
-			public boolean test() {
-				return app.getAppStatus() == status;
-			}
-		}, timeout, interval);
-		return app.getAppStatus() == status;
+		return waitForAppUpdate(app, a -> a.getAppStatus() == status, timeout, interval);
 	}
 	
 	public static boolean waitForBuildState(CodewindApplication app, BuildStatus status, long timeout, long interval) {
+		return waitForAppUpdate(app, a -> a.getBuildStatus() == status, timeout, interval);
+	}
+	
+	public static boolean waitForAppUpdate(CodewindApplication app, Predicate<CodewindApplication> tester, long timeout, long interval) {
 		TestUtil.wait(new Condition() {
 			@Override
 			public boolean test() {
-				return app.getBuildStatus() == status;
+				return tester.test(app);
 			}
 		}, timeout, interval);
-		return app.getBuildStatus() == status;
+		return tester.test(app);
 	}
 	
 	public static boolean checkStableAppStatus(CodewindApplication app, AppStatus status, long timeout, long interval) {


### PR DESCRIPTION
Fixes #571 

- Node projects need to restart when auto build mode is changed in order to turn on/off nodemon so need to make sure the application has finished restarting before trying to ping it
- Created a more generic method for app status testing