### PR TITLE
CW Issue #1710: Hide inject metrics action if app has embedded metrics (0.9.0)

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/EnableDisableInjectMetricsAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/EnableDisableInjectMetricsAction.java
@@ -87,7 +87,9 @@ public class EnableDisableInjectMetricsAction extends SelectionProviderAction {
 	
 	public boolean showAction() {
 		// Don't show the action if the app does not support inject metrics
-    	return (app != null && app.canInjectMetrics());
+		// Also don't show if the application already has metrics that are not injected
+		// (if injected, still need to allow the user to remove)
+		return (app != null && app.canInjectMetrics() && !(app.hasMetricsDashboard() && !app.isMetricsInjected()));
 	}
 
 }


### PR DESCRIPTION
If the application already has embedded metrics then there is no need to show the inject metrics action. If the application has injected metrics then the action should still show so the user has the option to remove it.