### PR TITLE
CW Issue #2079: Update for remove command changes

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/InstallUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/InstallUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -49,7 +49,7 @@ public class InstallUtil {
 	private static final String[] STOP_CMD = new String[] {"stop"};
 	private static final String[] STOP_ALL_CMD = new String[] {"stop-all"};
 	private static final String[] STATUS_CMD = new String[] {"status"};
-	private static final String[] REMOVE_CMD = new String[] {"remove"};
+	private static final String[] REMOVE_CMD = new String[] {"remove", "local"};
 	private static final String[] UPGRADE_CMD = new String[] {"upgrade"};
 	
 	public static final String DEFAULT_INSTALL_VERSION = "latest";


### PR DESCRIPTION
The remove command for removing Codewind images has been changed so the code in the IDE needs to be updated accordingly.  See https://github.com/eclipse/codewind-installer/pull/377 for details.