### PR TITLE
CW Issue #1252: Show restart in debug mode if capabilities support it

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
@@ -574,8 +574,9 @@ public class CodewindApplication {
 	}
 	
 	public boolean supportsDebug() {
-		// Override as needed
-		return false;
+		// Check if the project supports restart in debug mode
+		ProjectCapabilities capabilities = getProjectCapabilities();
+		return (capabilities.supportsDebugMode() || capabilities.supportsDebugNoInitMode()) && capabilities.canRestart();
 	}
 	
 	public void buildComplete() {

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
@@ -102,6 +102,9 @@ public class Messages extends NLS {
 	
 	public static String UpgradeResultMigrated;
 	public static String UpgradeResultNotMigrated;
+	
+	public static String DebugPortNotifyTitle;
+	public static String DebugPortNotifyMsg;
 
 	static {
 		// initialize resource bundle

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
@@ -96,3 +96,5 @@ ProcessHelperUnknownError=Unknown error
 UpgradeResultMigrated=The following projects were successfully migrated:
 UpgradeResultNotMigrated=Problems were encountered migrating these projects. Try manually adding them as existing projects to Codewind:
 
+DebugPortNotifyTitle=Debug port available for {0}
+DebugPortNotifyMsg=The debug port for {0} is now available: {1}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/AttachDebuggerAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/AttachDebuggerAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ package org.eclipse.codewind.ui.internal.actions;
 import org.eclipse.codewind.core.internal.CodewindEclipseApplication;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.constants.AppStatus;
-import org.eclipse.codewind.core.internal.constants.ProjectLanguage;
 import org.eclipse.codewind.core.internal.constants.StartMode;
 import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.jface.viewers.ISelectionProvider;
@@ -69,7 +68,7 @@ public class AttachDebuggerAction extends SelectionProviderAction {
     
     public boolean showAction() {
     	// Don't show the action if the app does not support debug
-    	return (app != null && app.connection.isLocal() && app.isAvailable() && app.supportsDebug());
+    	return (app != null && app.connection.isLocal() && app.isAvailable() && app.canInitiateDebugSession());
     }
 
 }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RestartDebugModeAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RestartDebugModeAction.java
@@ -26,9 +26,12 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.MessageDialogWithToggle;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.actions.SelectionProviderAction;
 
 /**
@@ -107,6 +110,17 @@ public class RestartDebugModeAction extends SelectionProviderAction {
 	        		return;
 	        	}
 	        }
+        } else if (!app.canInitiateDebugSession()) {
+        	// If can't attach or help launch a debugger, inform the user and allow them to cancel the operation
+        	MessageDialogWithToggle noDebugSessionQuestion = MessageDialogWithToggle.openOkCancelConfirm(
+					Display.getDefault().getActiveShell(), NLS.bind(Messages.NoDebugSetupDialogTitle, app.name),
+					Messages.NoDebugSetupDialogMsg,
+					Messages.NoDebugSetupDialogToggle, true, null, null);
+			if (noDebugSessionQuestion.getReturnCode() == IDialogConstants.CANCEL_ID) {
+				return;
+			}
+			// If the user requested it, notify them when the debug port becomes available
+			app.setDebugPortNotify(noDebugSessionQuestion.getToggleState());
         }
 
         try {

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -312,6 +312,10 @@ public class Messages extends NLS {
 	public static String ProjectOpenJob;
 	public static String ProjectOpenError;
 	
+	public static String NoDebugSetupDialogTitle;
+	public static String NoDebugSetupDialogMsg;
+	public static String NoDebugSetupDialogToggle;
+	
 	public static String BrowserTooltipApp;
 	public static String BrowserTooltipAppMonitor;
 	public static String BrowserTooltipPerformanceMonitor;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -306,6 +306,10 @@ ProjectClosedDialogMsg=There is no source available for debugging because the pr
 ProjectOpenJob=Open project {0}
 ProjectOpenError=An error occurred while trying to open the {0} project
 
+NoDebugSetupDialogTitle=Debug session setup not supported for {0}
+NoDebugSetupDialogMsg=Automatic setup of a debug session is not supported for this application type. You will need to attach a debugger manually when the debug port becomes available. The application may remain in starting state if a debugger is not attached.
+NoDebugSetupDialogToggle=Notify me when the debug port is available
+
 BrowserTooltipApp=Codewind Project: {0}
 BrowserTooltipAppMonitor=Metrics Dashboard: {0}
 BrowserTooltipPerformanceMonitor=Performance Dashboard: {0}


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/1252

Show the restart in debug mode action if the capabilities support it even if a debug session cannot be set up automatically for the user.  Show the user a dialog telling them they need to attach a debugger manually and give them the option to cancel along with the option to be notified when the debug port becomes available (on by default).