### PR TITLE
CW Issue #2327 - Add Filewatcher automated tests to FWd PR builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,12 @@ pipeline {
                 dir("dev") {
                     sh """#!/usr/bin/env bash
 
-                    export GIT_DIFF_OUTPUT=`git diff "$BRANCH_NAME" "$CHANGE_TARGET"`
+                    echo "Git output:"
+
+                    git diff "$BRANCH_NAME" "$CHANGE_TARGET"
+
+
+                    # export GIT_DIFF_OUTPUT=`git diff "$BRANCH_NAME" "$CHANGE_TARGET"`
 
                     printf %s "$GIT_DIFF_OUTPUT"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,13 +91,11 @@ pipeline {
 
                     echo pre
 
-                    git diff remotes/origin/"$CHANGE_TARGET"
+                    GIT_DIFF=`git diff remotes/origin/"$CHANGE_TARGET"`
+
+                    echo $GIT_DIFF
 
                     echo post
-
-                    git diff origin/"$CHANGE_TARGET"
-
-                    echo post2
 
                     # git diff remotes/origin/"$CHANGE_TARGET" master
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,9 +91,13 @@ pipeline {
 
                     echo pre
 
-                    git diff "@{upstream}"
+                    git diff remotes/origin/"$CHANGE_TARGET"
 
                     echo post
+
+                    git diff origin/"$CHANGE_TARGET"
+
+                    echo post2
 
                     # git diff remotes/origin/"$CHANGE_TARGET" master
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,9 @@ pipeline {
                         which java    
                     '''
                     
-                    dir('dev') { sh './gradlew --stacktrace' }
+                    dir('dev') { sh 'exit 0' }
+
+                    // dir('dev') { sh './gradlew --stacktrace' }
                 }
             }
         } 
@@ -92,9 +94,6 @@ pipeline {
                     # cd codewind-filewatchers
                     # git checkout "$BRANCH_NAME"
 
-
-
-
                     """
                 }
             }
@@ -106,6 +105,9 @@ pipeline {
                     println("Deploying codewind-eclipse to downoad area...")
                   
                     sh '''
+
+exit 0
+
                         export REPO_NAME="codewind-eclipse"
                         export OUTPUT_NAME="codewind"
                         export OUTPUT_DIR="$WORKSPACE/dev/ant_build/artifacts"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,19 +86,12 @@ pipeline {
                 dir("dev") {
                     sh """#!/usr/bin/env bash
 
-                    echo "Git output:"
-
-                    git remote -v
-
-                    git status
-
                     echo pre
 
-                    GIT_DIFF=`git diff remotes/origin/"$CHANGE_TARGET`
+                    export CHANGE_TARGET=\$CHANGE_TARGET
 
-                    CHANGE_COUNT=`printf %s "\$GIT_DIFF"`
-
-                    echo change count \$CHANGE_COUNT
+                    cd org.eclipse.codewind.filewatchers.standalonenio
+                    ./run_fwd_tests_if_needed.sh
 
                     echo post
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,9 +26,6 @@ pipeline {
             steps {
                 dir("dev/org.eclipse.codewind.core/binaries") {
                     sh """#!/usr/bin/env bash
-
-                        exit 0 
-
                         export VSCODE_REPO="https://github.com/eclipse/codewind-vscode.git"
                         export CW_VSCODE_BRANCH=master
 
@@ -73,9 +70,7 @@ pipeline {
                         which java    
                     '''
                     
-                    dir('dev') { sh 'exit 0' }
-
-                    // dir('dev') { sh './gradlew --stacktrace' }
+                    dir('dev') { sh './gradlew --stacktrace' }
                 }
             }
         } 
@@ -102,9 +97,6 @@ pipeline {
                     println("Deploying codewind-eclipse to downoad area...")
                   
                     sh '''
-
-exit 0
-
                         export REPO_NAME="codewind-eclipse"
                         export OUTPUT_NAME="codewind"
                         export OUTPUT_DIR="$WORKSPACE/dev/ant_build/artifacts"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,13 @@ pipeline {
 
                     git status
 
-                    git diff remotes/origin/"$CHANGE_TARGET" master
+                    echo pre
+
+                    git diff "@{upstream}"
+
+                    echo post
+
+                    # git diff remotes/origin/"$CHANGE_TARGET" master
 
                     # git diff "$BRANCH_NAME" "$CHANGE_TARGET"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,7 @@ pipeline {
 
                     # export GIT_DIFF_OUTPUT=`git diff "$BRANCH_NAME" "$CHANGE_TARGET"`
 
-                    printf %s "$GIT_DIFF_OUTPUT"
+                    # printf %s "$GIT_DIFF_OUTPUT"
 
                     # PR-595 and master
                     #echo "jgw: $BRANCH_NAME and $CHANGE_TARGET"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,9 @@ pipeline {
             steps {
                 dir("dev/org.eclipse.codewind.core/binaries") {
                     sh """#!/usr/bin/env bash
+
+                        exit 0 
+
                         export VSCODE_REPO="https://github.com/eclipse/codewind-vscode.git"
                         export CW_VSCODE_BRANCH=master
 
@@ -91,9 +94,11 @@ pipeline {
 
                     echo pre
 
-                    GIT_DIFF=`git diff remotes/origin/"$CHANGE_TARGET"`
+                    GIT_DIFF=`git diff remotes/origin/"$CHANGE_TARGET`
 
-                    printf %s "\$GIT_DIFF"
+                    CHANGE_COUNT=`printf %s "\$GIT_DIFF" | grep "Jenkins" | grep -v "filewatchers.eclipse" |  wc -l"`
+
+                    echo change count \$CHANGE_COUNT
 
                     echo post
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,7 @@ pipeline {
 
                     GIT_DIFF=`git diff remotes/origin/"$CHANGE_TARGET"`
 
-                    echo \$GIT_DIFF
+                    printf %s "\$GIT_DIFF"
 
                     echo post
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,6 +74,22 @@ pipeline {
                 }
             }
         } 
+
+
+        stage('Test') {
+            steps {
+                dir("dev") {
+                    sh """#!/usr/bin/env bash
+
+                    # GIT_DIFF_OUTPUT=`git diff $BRANCH_NAME $CHANGE_TARGET`
+
+                    echo "jgw: $BRANCH_NAME and $CHANGE_TARGET"
+
+
+                    """
+                }
+            }
+        }
         
         stage('Deploy') {
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,9 +81,9 @@ pipeline {
                 dir("dev") {
                     sh """#!/usr/bin/env bash
 
-                    GIT_DIFF_OUTPUT=`git diff $BRANCH_NAME $CHANGE_TARGET`
+                    export GIT_DIFF_OUTPUT=`git diff "$BRANCH_NAME" "$CHANGE_TARGET"`
 
-                    printf %s $GIT_DIFF_OUTPUT
+                    printf %s "$GIT_DIFF_OUTPUT"
 
                     # PR-595 and master
                     #echo "jgw: $BRANCH_NAME and $CHANGE_TARGET"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,10 +88,6 @@ pipeline {
                     git diff "$BRANCH_NAME" "$CHANGE_TARGET"
 
 
-                    # export GIT_DIFF_OUTPUT=`git diff "$BRANCH_NAME" "$CHANGE_TARGET"`
-
-                    # printf %s "$GIT_DIFF_OUTPUT"
-
                     # PR-595 and master
                     #echo "jgw: $BRANCH_NAME and $CHANGE_TARGET"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
 
                     GIT_DIFF=`git diff remotes/origin/"$CHANGE_TARGET`
 
-                    CHANGE_COUNT=`printf %s "\$GIT_DIFF" | grep "Jenkins" | grep -v "filewatchers.eclipse" |  wc -l"`
+                    CHANGE_COUNT=`printf %s "\$GIT_DIFF"`
 
                     echo change count \$CHANGE_COUNT
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,7 +85,13 @@ pipeline {
 
                     echo "Git output:"
 
-                    git diff "$BRANCH_NAME" "$CHANGE_TARGET"
+                    git remote -v
+
+                    git status
+
+                    git diff remotes/origin/"$CHANGE_TARGET" master
+
+                    # git diff "$BRANCH_NAME" "$CHANGE_TARGET"
 
 
                     # PR-595 and master

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,26 +86,10 @@ pipeline {
                 dir("dev") {
                     sh """#!/usr/bin/env bash
 
-                    echo pre
-
                     export CHANGE_TARGET=\$CHANGE_TARGET
 
                     cd org.eclipse.codewind.filewatchers.standalonenio
                     ./run_fwd_tests_if_needed.sh
-
-                    echo post
-
-                    # git diff remotes/origin/"$CHANGE_TARGET" master
-
-                    # git diff "$BRANCH_NAME" "$CHANGE_TARGET"
-
-
-                    # PR-595 and master
-                    #echo "jgw: $BRANCH_NAME and $CHANGE_TARGET"
-
-                    # git clone git@github.com:eclipse/codewind-filewatchers
-                    # cd codewind-filewatchers
-                    # git checkout "$BRANCH_NAME"
 
                     """
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,9 +81,18 @@ pipeline {
                 dir("dev") {
                     sh """#!/usr/bin/env bash
 
-                    # GIT_DIFF_OUTPUT=`git diff $BRANCH_NAME $CHANGE_TARGET`
+                    GIT_DIFF_OUTPUT=`git diff $BRANCH_NAME $CHANGE_TARGET`
 
-                    echo "jgw: $BRANCH_NAME and $CHANGE_TARGET"
+                    printf %s $GIT_DIFF_OUTPUT
+
+                    # PR-595 and master
+                    #echo "jgw: $BRANCH_NAME and $CHANGE_TARGET"
+
+                    # git clone git@github.com:eclipse/codewind-filewatchers
+                    # cd codewind-filewatchers
+                    # git checkout "$BRANCH_NAME"
+
+
 
 
                     """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,7 @@ pipeline {
 
                     GIT_DIFF=`git diff remotes/origin/"$CHANGE_TARGET"`
 
-                    echo $GIT_DIFF
+                    echo \$GIT_DIFF
 
                     echo post
 

--- a/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
+++ b/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
@@ -30,7 +30,6 @@ cd "$SCRIPT_LOCT"
 echo 
 echo "Download Maven and add to path"
 echo
-cd $STEP_ROOT_PATH
 curl -LO http://mirror.dsrg.utoronto.ca/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
 tar xzf apache-maven-3.6.3-bin.tar.gz
 cd apache-maven-3.6.3/bin

--- a/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
+++ b/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
@@ -12,7 +12,7 @@ GIT_DIFF=`git diff remotes/origin/"$CHANGE_TARGET"`
 
 printf %s "$GIT_DIFF"
 
-CHANGE_COUNT=`printf %s "$GIT_DIFF" | grep "filewatchers" | grep -v "filewatchers.eclipse" |  wc -l`
+CHANGE_COUNT=`printf %s "$GIT_DIFF" | grep "diff --git" | grep "eclipse.codewind.filewatchers" | grep -v "filewatchers.eclipse" |  wc -l`
 
 if [ "$CHANGE_COUNT" == "0" ]; then
 	echo "* No filewatcherd changes detected in Git diff list."
@@ -21,10 +21,20 @@ fi
 
 set -euo pipefail
 
-
 echo change count $CHANGE_COUNT
 
-echo post
+
+cd "$SCRIPT_LOCT"
+
+
+echo 
+echo "Download Maven and add to path"
+echo
+cd $STEP_ROOT_PATH
+curl -LO http://mirror.dsrg.utoronto.ca/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
+tar xzf apache-maven-3.6.3-bin.tar.gz
+cd apache-maven-3.6.3/bin
+export PATH=`pwd`:$PATH
 
 
 cd "$SCRIPT_LOCT"
@@ -37,6 +47,8 @@ mvn package
 
 ls -l target/
 
+
+echo post
 
 
 # git diff remotes/origin/"$CHANGE_TARGET" master

--- a/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
+++ b/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
@@ -46,6 +46,16 @@ mvn package
 
 ls -l target/
 
+
+cd "$SCRIPT_LOCT"
+git clone "https://github.com/eclipse/codewind-filewatchers"
+cd codewind-filewatchers
+git checkout "$CHANGE_TARGET"
+cd Tests/
+
+./run_tests_java_filewatcher_on_target.sh "$SCRIPT_LOCT/../.."
+
+
 echo post
 
 

--- a/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
+++ b/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
@@ -35,17 +35,16 @@ tar xzf apache-maven-3.6.3-bin.tar.gz
 cd apache-maven-3.6.3/bin
 export PATH=`pwd`:$PATH
 
-
-cd "$SCRIPT_LOCT"
+cd "$SCRIPT_LOCT/../org.eclipse.codewind.filewatchers.core"
 
 mvn install
 
-cd "$SCRIPT_LOCT/../org.eclipse.codewind.filewatchers.core"
+
+cd "$SCRIPT_LOCT"
 
 mvn package
 
 ls -l target/
-
 
 echo post
 

--- a/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
+++ b/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
@@ -1,4 +1,15 @@
 #!/usr/bin/env bash
+#
+#*******************************************************************************
+# Copyright (c) 2020 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
 
 export SCRIPT_LOCT=`dirname $0`
 export SCRIPT_LOCT=`cd $SCRIPT_LOCT; pwd`

--- a/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
+++ b/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
@@ -38,7 +38,7 @@ export PATH=`pwd`:$PATH
 
 cd "$SCRIPT_LOCT"
 
-mvn install org.eclipse.codewind.filewatchers.standalonenio
+mvn install
 
 cd "$SCRIPT_LOCT/../org.eclipse.codewind.filewatchers.core"
 

--- a/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
+++ b/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
@@ -3,18 +3,41 @@
 export SCRIPT_LOCT=`dirname $0`
 export SCRIPT_LOCT=`cd $SCRIPT_LOCT; pwd`
 cd $SCRIPT_LOCT
-set -euo pipefail
 
 
 echo pre
 
+
 GIT_DIFF=`git diff remotes/origin/"$CHANGE_TARGET"`
 
-CHANGE_COUNT=`printf %s "$GIT_DIFF" | grep "Jenkins" | grep -v "filewatchers.eclipse" |  wc -l`
+printf %s "$GIT_DIFF"
+
+CHANGE_COUNT=`printf %s "$GIT_DIFF" | grep "filewatchers" | grep -v "filewatchers.eclipse" |  wc -l`
+
+if [ "$CHANGE_COUNT" == "0" ]; then
+	echo "* No filewatcherd changes detected in Git diff list."
+    exit 0
+fi
+
+set -euo pipefail
+
 
 echo change count $CHANGE_COUNT
 
 echo post
+
+
+cd "$SCRIPT_LOCT"
+
+mvn install org.eclipse.codewind.filewatchers.standalonenio
+
+cd "$SCRIPT_LOCT/../org.eclipse.codewind.filewatchers.core"
+
+mvn package
+
+ls -l target/
+
+
 
 # git diff remotes/origin/"$CHANGE_TARGET" master
 

--- a/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
+++ b/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 echo pre
 
-GIT_DIFF=`git diff remotes/origin/"$CHANGE_TARGET`
+GIT_DIFF=`git diff remotes/origin/"$CHANGE_TARGET"`
 
 CHANGE_COUNT=`printf %s "$GIT_DIFF" | grep "Jenkins" | grep -v "filewatchers.eclipse" |  wc -l"`
 

--- a/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
+++ b/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
@@ -5,12 +5,7 @@ export SCRIPT_LOCT=`cd $SCRIPT_LOCT; pwd`
 cd $SCRIPT_LOCT
 
 
-echo pre
-
-
 GIT_DIFF=`git diff remotes/origin/"$CHANGE_TARGET"`
-
-printf %s "$GIT_DIFF"
 
 CHANGE_COUNT=`printf %s "$GIT_DIFF" | grep "diff --git" | grep "eclipse.codewind.filewatchers" | grep -v "filewatchers.eclipse" |  wc -l`
 
@@ -19,34 +14,36 @@ if [ "$CHANGE_COUNT" == "0" ]; then
     exit 0
 fi
 
+# Output Git Diff for debug purposes, until the above code matures.
+echo "Git Diff:"
+printf %s "$GIT_DIFF"
+
+
 set -euo pipefail
-
-echo change count $CHANGE_COUNT
-
-
-cd "$SCRIPT_LOCT"
 
 
 echo 
 echo "Download Maven and add to path"
 echo
+cd "$SCRIPT_LOCT"
 curl -LO http://mirror.dsrg.utoronto.ca/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
 tar xzf apache-maven-3.6.3-bin.tar.gz
 cd apache-maven-3.6.3/bin
 export PATH=`pwd`:$PATH
 
+
+echo
+echo "Building Java filewatcher"
+echo
 cd "$SCRIPT_LOCT/../org.eclipse.codewind.filewatchers.core"
-
 mvn install
-
-
 cd "$SCRIPT_LOCT"
-
 mvn package
 
-ls -l target/
 
-
+echo
+echo "Build and run test suite"
+echo
 cd "$SCRIPT_LOCT"
 git clone "https://github.com/eclipse/codewind-filewatchers"
 cd codewind-filewatchers
@@ -55,18 +52,3 @@ cd Tests/
 
 ./run_tests_java_filewatcher_on_target.sh "$SCRIPT_LOCT/../.."
 
-
-echo post
-
-
-# git diff remotes/origin/"$CHANGE_TARGET" master
-
-# git diff "$BRANCH_NAME" "$CHANGE_TARGET"
-
-
-# PR-595 and master
-#echo "jgw: $BRANCH_NAME and $CHANGE_TARGET"
-
-# git clone git@github.com:eclipse/codewind-filewatchers
-# cd codewind-filewatchers
-# git checkout "$BRANCH_NAME"

--- a/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
+++ b/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+export SCRIPT_LOCT=`dirname $0`
+export SCRIPT_LOCT=`cd $SCRIPT_LOCT; pwd`
+cd $SCRIPT_LOCT
+set -euo pipefail
+
+
+echo pre
+
+GIT_DIFF=`git diff remotes/origin/"$CHANGE_TARGET`
+
+CHANGE_COUNT=`printf %s "$GIT_DIFF" | grep "Jenkins" | grep -v "filewatchers.eclipse" |  wc -l"`
+
+echo change count $CHANGE_COUNT
+
+echo post
+
+# git diff remotes/origin/"$CHANGE_TARGET" master
+
+# git diff "$BRANCH_NAME" "$CHANGE_TARGET"
+
+
+# PR-595 and master
+#echo "jgw: $BRANCH_NAME and $CHANGE_TARGET"
+
+# git clone git@github.com:eclipse/codewind-filewatchers
+# cd codewind-filewatchers
+# git checkout "$BRANCH_NAME"

--- a/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
+++ b/dev/org.eclipse.codewind.filewatchers.standalonenio/run_fwd_tests_if_needed.sh
@@ -10,7 +10,7 @@ echo pre
 
 GIT_DIFF=`git diff remotes/origin/"$CHANGE_TARGET"`
 
-CHANGE_COUNT=`printf %s "$GIT_DIFF" | grep "Jenkins" | grep -v "filewatchers.eclipse" |  wc -l"`
+CHANGE_COUNT=`printf %s "$GIT_DIFF" | grep "Jenkins" | grep -v "filewatchers.eclipse" |  wc -l`
 
 echo change count $CHANGE_COUNT
 

--- a/dev/org.eclipse.codewind.filewatchers.standalonenio/src/org/eclipse/codewind/filewatchers/Main.java
+++ b/dev/org.eclipse.codewind.filewatchers.standalonenio/src/org/eclipse/codewind/filewatchers/Main.java
@@ -38,7 +38,7 @@ public class Main {
 			}
 
 		} else {
-			System.err.println("Argument should be URL to server instance.");
+			System.err.println("Argument should be URL to server instance!");
 			return;
 		}
 

--- a/dev/org.eclipse.codewind.filewatchers.standalonenio/src/org/eclipse/codewind/filewatchers/Main.java
+++ b/dev/org.eclipse.codewind.filewatchers.standalonenio/src/org/eclipse/codewind/filewatchers/Main.java
@@ -38,7 +38,7 @@ public class Main {
 			}
 
 		} else {
-			System.err.println("Argument should be URL to server instance!");
+			System.err.println("Argument should be URL to server instance.");
 			return;
 		}
 


### PR DESCRIPTION
Add the filewatcher tests to the PR build, but ensure that the tests only run if a file changed under one of the `org.eclipse.codewind.filewatchers.*` projects. This should prevent the tests from running for non-filewatcher PRs.

Parent issue: https://github.com/eclipse/codewind/issues/2327