### PR TITLE
CW Issue #2299: remove ping test from open perf dashboard

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
@@ -412,7 +412,7 @@ public class CodewindApplication {
 	}
 	
 	public synchronized boolean hasPerfDashboard() {
-		return metricsAvailable && perfPath != null;
+		return perfPath != null;
 	}
 	
 	public synchronized void setMetricsInjectionInfo(boolean injectable, boolean injected) {

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/OpenPerfMonitorAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/OpenPerfMonitorAction.java
@@ -68,7 +68,6 @@ public class OpenPerfMonitorAction extends SelectionProviderAction {
         	return;
         }
         
-        app.confirmMetricsAvailable();
         if (!app.hasPerfDashboard()) {
         	CoreUtil.openDialog(true, Messages.GenericActionNotSupported, Messages.PerfDashboardNotSupported);
         	return;


### PR DESCRIPTION
The ping test is no longer needed for the performance dashboard action.