### PR TITLE
CW Issue #2336: Copy FontData instead of overwriting when creating fonts

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/IDEUtil.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/IDEUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -69,14 +69,6 @@ public class IDEUtil {
 		return result[0];
 	}
     
-	public static Font getBoldFont(Shell shell, Font font) {
-		Display display = shell.getDisplay();
-		FontData[] fontData = font.getFontData();
-		fontData[0].setStyle(SWT.BOLD);
-		fontData[0].setHeight(fontData[0].getHeight());
-		return new Font(display, fontData);
-	}
-    
     public static void setBold(StyledText text) {
 		StyleRange range = new StyleRange();
 		range.start = 0;
@@ -104,5 +96,15 @@ public class IDEUtil {
     	return new MultiStatus(CodewindUIPlugin.PLUGIN_ID, IStatus.ERROR,
     			statusList.toArray(new Status[statusList.size()]), e.toString(), e);
     }
+
+	// Fonts returned by this method must be disposed!
+	public static Font newFont(Shell shell, Font font, int style) {
+		FontData[] data = font.getFontData();
+		FontData[] newData = new FontData[data.length];
+		for (int i = 0; i < data.length; i++) {
+			newData[i] = new FontData(data[i].getName(), data[i].getHeight(), data[i].getStyle() | style);
+		}
+		return new Font(shell.getDisplay(), newData);
+	}
 
 }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
@@ -205,7 +205,7 @@ public class ApplicationOverviewEditorPart extends EditorPart {
 		messageLabel = toolkit.createLabel(messageComp, "");
 		messageLabel.setLayoutData(new GridData(GridData.FILL_HORIZONTAL | GridData.VERTICAL_ALIGN_FILL));
 		
-		boldFont = IDEUtil.getBoldFont(parent.getShell(), parent.getFont());
+		boldFont = IDEUtil.newFont(parent.getShell(), parent.getFont(), SWT.BOLD);
 		
 		sectionComp = toolkit.createComposite(form.getBody());
 		GridLayout layout = new GridLayout();

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/RepositoryManagementComposite.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/RepositoryManagementComposite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -180,7 +180,7 @@ public class RepositoryManagementComposite extends Composite {
 		detailsComp.setLayout(detailsLayout);
 		detailsComp.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, true));
 		
-		boldFont = IDEUtil.getBoldFont(getShell(), getFont());
+		boldFont = IDEUtil.newFont(getShell(), getFont(), SWT.BOLD);
 		
 		descLabel = new Label(detailsComp, SWT.NONE);
 		descLabel.setFont(boldFont);

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectValidationPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectValidationPage.java
@@ -87,7 +87,7 @@ public class ProjectValidationPage extends WizardPage {
 		
 		new Label(composite, SWT.NONE).setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, false, false, 2, 1));
 		
-		boldFont = IDEUtil.getBoldFont(getShell(), getFont());
+		boldFont = IDEUtil.newFont(getShell(), getFont(), SWT.BOLD);
         
 		typeLabel = new Label(composite, SWT.NONE);
 		typeLabel.setText("Type:");


### PR DESCRIPTION
Fixes #2336

Copy FontData instead of overwriting it when creating a new font based on an existing font.