### PR TITLE
CW Issue #2339: Update copyright and link in about.properties

### DIFF
--- a/dev/org.eclipse.codewind.core/about.properties
+++ b/dev/org.eclipse.codewind.core/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2019 IBM Corporation and others.
+# Copyright (c) 2018, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v2.0
 # which accompanies this distribution, and is available at
@@ -20,5 +20,5 @@ Build id: {1}\n\
 \n\
 Tools for working with Codewind applications in Eclipse.\n\
 \n\
-Copyright \u00a9 IBM Corporation and others 2018, 2019. All rights reserved.\n\
-Visit https://microclimate-dev2ops.github.io/
+Copyright \u00a9 IBM Corporation and others 2018, 2020. All rights reserved.\n\
+Visit https://www.eclipse.org/codewind/


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/2339

Update the copyright and link in the branding file (about.properties).