### PR TITLE
CW Issue #2355: Add mnemonic for the new connection menu item

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/AddConnectionAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/AddConnectionAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ package org.eclipse.codewind.ui.internal.actions;
 import org.eclipse.codewind.core.internal.CodewindManager;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
+import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.codewind.ui.internal.wizards.NewCodewindConnectionWizard;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -27,7 +28,7 @@ import org.eclipse.ui.actions.SelectionProviderAction;
 public class AddConnectionAction extends SelectionProviderAction {
 
 	public AddConnectionAction(ISelectionProvider selectionProvider) {
-		super(selectionProvider, "New Connection");
+		super(selectionProvider, Messages.NewConnectionActionLabel);
 		setImageDescriptor(CodewindUIPlugin.getImageDescriptor(CodewindUIPlugin.NEW_REMOTE_ICON));
 		selectionChanged(getStructuredSelection());
 	}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -41,6 +41,7 @@ public class Messages extends NLS {
 	public static String PrefsParentPage_DebugTimeoutLabel;
 	public static String PrefsParentPage_ErrInvalidTimeout;
 
+	public static String NewConnectionActionLabel;
 	public static String NewConnectionPage_ShellTitle;
 	public static String NewConnectionPage_WizardDescription;
 	public static String NewConnectionPage_WizardTitle;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -34,6 +34,7 @@ PrefsParentPage_StopAppsPrompt=&Prompt
 PrefsParentPage_DebugTimeoutLabel=&Timeout for the server debug connection in seconds:
 PrefsParentPage_ErrInvalidTimeout=The timeout value "{0}" is not valid. Enter an integer greater than 0.
 
+NewConnectionActionLabel=New &Connection
 NewConnectionPage_ShellTitle=New Codewind connection
 NewConnectionPage_WizardDescription=Create a connection to a Codewind instance.
 NewConnectionPage_WizardTitle=Create a Codewind connection


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/2355

The new connection menu item should have a mnemonic for accessibility support.