### PR TITLE
CW Issue #2433: Fix NPE on shutdown when ConnectionManager not initialized

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnectionManager.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnectionManager.java
@@ -154,6 +154,11 @@ public class CodewindConnectionManager {
 	 * Deletes all of the instance's connections. Called when the plugin is stopped.
 	 */
 	public synchronized static void clear() {
+		if (instance == null) {
+			// Never initialized so just return
+			return;
+		}
+		
 		Logger.log("Clearing " + instance().connections.size() + " connections"); //$NON-NLS-1$ //$NON-NLS-2$
 
 		Iterator<CodewindConnection> it = instance().connections.iterator();


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/2433

Fix NPE on Eclipse shutdown when ConnectionManager not initialized.