### PR TITLE
CW Issue #2426: Add the host and port to the debug target name

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
@@ -34,7 +34,7 @@ ReconnectJob_ReconnectJobName=Trying to reconnect to Codewind at {0}
 ReconnectJob_ReconnectErrorDialogTitle=Error reconnecting to Codewind
 ReconnectJob_ReconnectErrorDialogMsg=Eclipse could not reconnect to {0}.\nRecreate this connection in the Codewind connection preferences.
 
-DebugLaunchConfigName=Debugging {0}
+DebugLaunchConfigName=Debugging {0} at {1}:{2}
 DebuggerConnectFailureDialogTitle=The debugger failed to connect
 DebuggerConnectFailureDialogMsg=The debugger failed to connect in time. Increase the debug timeout in the Codewind preferences.
 


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/2426

Add the host and port to the debug target name. They were already being passed to NLS.bind so just needed to fix the message.