### PR TITLE
CW Issue #2424: Show connection unavailable msg in app overview page if connection lost

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindManager.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -93,7 +93,7 @@ public class CodewindManager {
 	
 	public void setInstallerStatus(InstallerStatus status) {
 		this.installerStatus = status;
-		CoreUtil.updateAll();
+		CoreUtil.updateConnection(CodewindConnectionManager.getLocalConnection());
 	}
 
 	public boolean isSupportedVersion(String version) {

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/connection/CodewindConnection.java
@@ -860,8 +860,7 @@ public class CodewindConnection {
 		synchronized(appMap) {
 			appMap.clear();
 		}
-		// Update everything as Codewind might be down as well
-		CoreUtil.updateAll();
+		CoreUtil.updateConnection(this);
 	}
 
 	/**
@@ -891,21 +890,21 @@ public class CodewindConnection {
 					Logger.logError("Failed to create a new socket with updated URI: " + socket.socketUri);
 					// Clear the message so that it just shows the basic disconnected message
 					this.connectionErrorMsg = null;
-					CoreUtil.updateAll();
+					CoreUtil.updateConnection(this);
 					return;
 				}
 			}
 		} catch (Exception e) {
 			Logger.logError("An exception occurred while trying to update the connection information", e);
 			this.connectionErrorMsg = Messages.Connection_ErrConnection_UpdateCacheException;
-			CoreUtil.updateAll();
+			CoreUtil.updateConnection(this);
 			return;
 		}
 		
 		this.connectionErrorMsg = null;
 		isConnected = true;
 		refreshApps(null);
-		CoreUtil.updateAll();
+		CoreUtil.updateConnection(this);
 	}
 
 	@Override

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
@@ -264,9 +264,18 @@ public class ApplicationOverviewEditorPart extends EditorPart implements UpdateL
 					break;
 				}
 			});
-		} else if (element instanceof CodewindConnection && ((CodewindConnection)element).getConid().equals(connectionId) && type == UpdateType.REMOVE) {
+		} else if (element instanceof CodewindConnection && ((CodewindConnection)element).getConid().equals(connectionId)) {
 			Display.getDefault().asyncExec(() -> {
-				ApplicationOverviewEditorPart.this.getEditorSite().getPage().closeEditor(ApplicationOverviewEditorPart.this, false);
+				switch(type) {
+				case MODIFY:
+					CodewindConnection conn = (CodewindConnection)element;
+					CodewindApplication app = conn.getAppByID(projectId);
+					ApplicationOverviewEditorPart.this.update(conn, app);
+					break;
+				case REMOVE:
+					ApplicationOverviewEditorPart.this.getEditorSite().getPage().closeEditor(ApplicationOverviewEditorPart.this, false);
+					break;
+				}
 			});
 		}
 	}
@@ -277,11 +286,11 @@ public class ApplicationOverviewEditorPart extends EditorPart implements UpdateL
 	
 	public void update(CodewindConnection conn, CodewindApplication app, boolean init) {
 		boolean changed = false;
-		if (conn == null || app == null) {
+		if (conn == null || !conn.isConnected() || app == null) {
 			changed = !messageComp.getVisible();
 			messageComp.setVisible(true);
 			((GridData)messageComp.getLayoutData()).exclude = false;
-			messageLabel.setText(conn == null ? Messages.AppOverviewEditorNoConnection : Messages.AppOverviewEditorNoApplication);
+			messageLabel.setText(conn == null || !conn.isConnected() ? Messages.AppOverviewEditorNoConnection : Messages.AppOverviewEditorNoApplication);
 			sectionComp.setVisible(false);
 			((GridData)sectionComp.getLayoutData()).exclude = true;
 		} else {


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/2424

Show the connection unavailable message in the application overview page if the connection is lost. This is the same as what shows when Eclipse is first started for any application overview pages until the connections are re-established.

Also changed some calls to CoreUtil.updateAll to CoreUtil.updateConnection. These probably date back to when there was only one connection. The only time updateAll needs to be called now is when a connection is added.