### PR TITLE
CW Issue #2309: Check for terminal service bundles before opening container shell

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/ContainerShellAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/ContainerShellAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -18,8 +18,11 @@ import org.eclipse.codewind.core.internal.CodewindApplication;
 import org.eclipse.codewind.core.internal.CoreUtil;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.ui.internal.messages.Messages;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.tm.terminal.view.core.TerminalServiceFactory;
 import org.eclipse.tm.terminal.view.core.interfaces.ITerminalService;
 import org.eclipse.tm.terminal.view.core.interfaces.constants.ITerminalsConnectorConstants;
@@ -30,6 +33,8 @@ import org.eclipse.ui.actions.SelectionProviderAction;
  */
 public class ContainerShellAction extends SelectionProviderAction {
 	
+	private static final String TERMINAL_SERVICE_BUNDLE_ID = "org.eclipse.tm.terminal.view.core"; //$NON-NLS-1$
+	private static final String LAUNCHER_BUNDLE_ID = "org.eclipse.tm.terminal.connector.local"; //$NON-NLS-1$
 	private static final String LAUNCHER_DELEGATE_ID = "org.eclipse.tm.terminal.connector.local.launcher.local"; //$NON-NLS-1$
 	
     protected CodewindApplication app;
@@ -63,6 +68,13 @@ public class ContainerShellAction extends SelectionProviderAction {
         if (app.getContainerId() == null) {
         	Logger.logError("ContainerShellAction ran but the container id for the application is not set: " + app.name); //$NON-NLS-1$
 			return;
+        }
+        
+        // Check that the required bundles are installed and show a dialog if not
+        if (Platform.getBundle(TERMINAL_SERVICE_BUNDLE_ID) == null || Platform.getBundle(LAUNCHER_BUNDLE_ID) == null) {
+        	Logger.logError("The container shell cannot be opened because the required terminal service dependencies are not installed."); //$NON-NLS-1$
+        	MessageDialog.openError(Display.getDefault().getActiveShell(), Messages.ActionOpenContainerShellMissingDepsTitle, Messages.ActionOpenContainerShellMissingDepsMsg);
+        	return;
         }
         
         // exec bash if it's installed, else exec sh

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -291,6 +291,8 @@ public class Messages extends NLS {
 	public static String ActionOpenTektonDashboardOtherError;
 	
 	public static String ActionOpenContainerShell;
+	public static String ActionOpenContainerShellMissingDepsTitle;
+	public static String ActionOpenContainerShellMissingDepsMsg;
 
 	public static String ValidateLabel;
 	public static String AttachDebuggerLabel;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -285,6 +285,8 @@ ActionOpenTektonDashboardNotInstalled=Tekton Dashboard does not appear to be ins
 ActionOpenTektonDashboardOtherError=There was an error detecting the Tekton Dashboard installation on this cluster. Please install or re-install Tekton Dashboard on your cluster.
 
 ActionOpenContainerShell=Open &Container Shell
+ActionOpenContainerShellMissingDepsTitle=Container Shell Missing Dependencies
+ActionOpenContainerShellMissingDepsMsg=The container shell cannot be opened because of missing dependencies. Check that you are using the Eclipse IDE for Enterprise Java Developers.
 
 ValidateLabel=Validate
 AttachDebuggerLabel=A&ttach Debugger


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix

- [ ] Enhancement

## What does this PR do ?
When opening the container shell, checks for the terminal service bundles. If they are not installed then an error dialog is shown to the user asking them to check that they are using the Eclipse IDE for Java Enterprise Java Developers.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2309

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No