### PR TITLE
CW Issue #2529: Fix the read only text background for Windows dark mode

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/IDEUtil.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/IDEUtil.java
@@ -91,6 +91,13 @@ public class IDEUtil {
     	control.setForeground(parent.getForeground());
     }
     
+	public static void paintBackgroundToMatch(Control control, Control parent) {
+		control.addPaintListener(event -> {
+			control.setBackground(parent.getBackground());
+			control.setForeground(parent.getForeground());
+		});
+	}
+    
 	public static void setControlVisibility(Control control, boolean visible) {
 		control.setVisible(visible);
 		((GridData)control.getLayoutData()).exclude = !visible;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
@@ -614,7 +614,7 @@ public class ApplicationOverviewEditorPart extends EditorPart implements UpdateL
 	        text = new Text(composite, SWT.WRAP | SWT.MULTI | SWT.READ_ONLY);
 	        text.setData(FormToolkit.KEY_DRAW_BORDER, Boolean.FALSE);
 	        text.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, true, false));
-	        IDEUtil.normalizeBackground(text, composite);
+	        IDEUtil.paintBackgroundToMatch(text, composite);
 		}
 		
 		public void setValue(String value, boolean visible) {
@@ -655,7 +655,7 @@ public class ApplicationOverviewEditorPart extends EditorPart implements UpdateL
 			text.setData(FormToolkit.KEY_DRAW_BORDER, Boolean.FALSE);
 			text.setText(Messages.AppOverviewEditorNotAvailable);
 			text.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, false, false));
-			IDEUtil.normalizeBackground(text, composite);
+			IDEUtil.paintBackgroundToMatch(text, composite);
 	        
 			link = toolkit.createHyperlink(composite, "", SWT.WRAP);
 			link.setVisible(false);

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/WelcomePageEditorPart.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/WelcomePageEditorPart.java
@@ -156,7 +156,7 @@ public class WelcomePageEditorPart extends EditorPart implements UpdateListener 
 		int borderStyle = toolkit.getBorderStyle();
 		toolkit.setBorderStyle(SWT.NONE);
 		Text welcomeText = toolkit.createText(welcomeComp, Messages.WelcomePageWelcomeText, SWT.WRAP | SWT.READ_ONLY);
-		IDEUtil.normalizeBackground(welcomeText, welcomeComp);
+		IDEUtil.paintBackgroundToMatch(welcomeText, welcomeComp);
 		welcomeText.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 		toolkit.setBorderStyle(borderStyle);
 		
@@ -179,7 +179,7 @@ public class WelcomePageEditorPart extends EditorPart implements UpdateListener 
 		borderStyle = toolkit.getBorderStyle();
 		toolkit.setBorderStyle(SWT.NONE);
 		Text quickStartText = toolkit.createText(quickStartComp, Messages.WelcomePageQuickStartText, SWT.WRAP | SWT.READ_ONLY);
-		IDEUtil.normalizeBackground(welcomeText, quickStartComp);
+		IDEUtil.paintBackgroundToMatch(quickStartText, quickStartComp);
 		quickStartText.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 2, 1));
 		toolkit.setBorderStyle(borderStyle);
 		
@@ -249,7 +249,7 @@ public class WelcomePageEditorPart extends EditorPart implements UpdateListener 
 		borderStyle = toolkit.getBorderStyle();
 		toolkit.setBorderStyle(SWT.NONE);
 		Text commandsText = toolkit.createText(learnInnerComp, Messages.WelcomePageLearnCommandsText, SWT.WRAP | SWT.READ_ONLY);
-		IDEUtil.normalizeBackground(commandsText, learnInnerComp);
+		IDEUtil.paintBackgroundToMatch(commandsText, learnInnerComp);
 		commandsText.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 		toolkit.setBorderStyle(borderStyle);
 		
@@ -274,7 +274,7 @@ public class WelcomePageEditorPart extends EditorPart implements UpdateListener 
 		borderStyle = toolkit.getBorderStyle();
 		toolkit.setBorderStyle(SWT.NONE);
 		Text docsText = toolkit.createText(learnInnerComp, Messages.WelcomePageLearnDocsText, SWT.WRAP | SWT.READ_ONLY);
-		IDEUtil.normalizeBackground(docsText, learnInnerComp);
+		IDEUtil.paintBackgroundToMatch(docsText, learnInnerComp);
 		docsText.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 		toolkit.setBorderStyle(borderStyle);
 		
@@ -303,7 +303,7 @@ public class WelcomePageEditorPart extends EditorPart implements UpdateListener 
 		borderStyle = toolkit.getBorderStyle();
 		toolkit.setBorderStyle(SWT.NONE);
 		Text extensionsText = toolkit.createText(learnInnerComp, Messages.WelcomePageLearnExtensionsText, SWT.WRAP | SWT.READ_ONLY);
-		IDEUtil.normalizeBackground(extensionsText, learnInnerComp);
+		IDEUtil.paintBackgroundToMatch(extensionsText, learnInnerComp);
 		extensionsText.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 		toolkit.setBorderStyle(borderStyle);
 		


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Fixes up the read only text background for dark mode on Windows.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2529

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
Tried to find a more static method of doing this but every time I scrolled it went back to the wrong background so added a PaintListener.

Tested on Windows including high contrast mode and on Linux. Don't have access to a MAC machine right now.