### PR TITLE
CW Issue #2520: Support disabling keyring access

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/CodewindCorePlugin.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/CodewindCorePlugin.java
@@ -36,13 +36,14 @@ public class CodewindCorePlugin extends AbstractUIPlugin {
 	
 	public static final String DEFAULT_ICON_PATH = "icons/codewind.png"; //$NON-NLS-1$
 	
-	public static final String CW_INSTALL_TIMEOUT = "cwInstallTimeout";
-	public static final String CW_START_TIMEOUT = "cwStartTimeout";
-	public static final String CW_STOP_TIMEOUT = "cwStopTimeout";
-	public static final String CW_UNINSTALL_TIMEOUT = "cwUninstallTimeout";
+	public static final String CW_INSTALL_TIMEOUT = "cwInstallTimeout"; //$NON-NLS-1$
+	public static final String CW_START_TIMEOUT = "cwStartTimeout"; //$NON-NLS-1$
+	public static final String CW_STOP_TIMEOUT = "cwStopTimeout"; //$NON-NLS-1$
+	public static final String CW_UNINSTALL_TIMEOUT = "cwUninstallTimeout"; //$NON-NLS-1$
 	
-	public static final String AUTO_OPEN_OVERVIEW_PAGE = "autoOpenOverviewPage";
-	public static final String ENABLE_SUPPORT_FEATURES = "enableSupportFeatures";
+	public static final String AUTO_OPEN_OVERVIEW_PAGE = "autoOpenOverviewPage"; //$NON-NLS-1$
+	public static final String ENABLE_KEYRING_ACCESS = "enabledKeyringAccess"; //$NON-NLS-1$
+	public static final String ENABLE_SUPPORT_FEATURES = "enableSupportFeatures"; //$NON-NLS-1$
 
 	public static final String
 			// Int option for debug timeout in seconds
@@ -83,6 +84,7 @@ public class CodewindCorePlugin extends AbstractUIPlugin {
 		getPreferenceStore().setDefault(CW_START_TIMEOUT, InstallUtil.START_TIMEOUT_DEFAULT);
 		getPreferenceStore().setDefault(CW_STOP_TIMEOUT, InstallUtil.STOP_TIMEOUT_DEFAULT);
 		getPreferenceStore().setDefault(AUTO_OPEN_OVERVIEW_PAGE, true);
+		getPreferenceStore().setDefault(ENABLE_KEYRING_ACCESS, true);
 		getPreferenceStore().setDefault(ENABLE_SUPPORT_FEATURES, false);
 	}
 

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/CLIUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/CLIUtil.java
@@ -32,9 +32,7 @@ import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.PlatformUtil;
 import org.eclipse.codewind.core.internal.PlatformUtil.OperatingSystem;
 import org.eclipse.codewind.core.internal.ProcessHelper.ProcessResult;
-import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -45,6 +43,7 @@ public class CLIUtil {
 	// Global options
 	public static final String JSON_OPTION = "--json";
 	public static final String INSECURE_OPTION = "--insecure";
+	public static final String INSECURE_KEYRING_OPTION = "--insecureKeyring";
 	public static final String[] GLOBAL_JSON = new String[] {JSON_OPTION};
 	public static final String[] GLOBAL_INSECURE = new String[] {INSECURE_OPTION};
 	public static final String[] GLOBAL_JSON_INSECURE = new String[] {JSON_OPTION, INSECURE_OPTION};
@@ -91,6 +90,9 @@ public class CLIUtil {
 		
 		List<String> cmdList = new ArrayList<String>();
 		cmdList.add(codewindInfo.getInstallPath());
+		if (!CodewindCorePlugin.getDefault().getPreferenceStore().getBoolean(CodewindCorePlugin.ENABLE_KEYRING_ACCESS)) {
+			cmdList.add(INSECURE_KEYRING_OPTION);
+		}
 		addOptions(cmdList, globalOptions);
 		addOptions(cmdList, cmd);
 		addOptions(cmdList, options);
@@ -221,5 +223,19 @@ public class CLIUtil {
 		}
 		
 		Logger.log(String.format("Result of the cwctl '%s' command: \n%s", CoreUtil.formatString(command, " "), Optional.ofNullable(result.getOutput()).orElse("<empty>")));
+	}
+	
+	public static String getErrorKey(ProcessResult result) {
+		try {
+			if (result.getOutput() != null && !result.getOutput().isEmpty()) {
+				JSONObject obj = new JSONObject(result.getOutput());
+				if (obj.has(ERROR_KEY)) {
+					return obj.getString(ERROR_KEY);
+				}
+			}
+		} catch (JSONException e) {
+			// Ignore
+		}
+		return null;
 	}
 }

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/InstallUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/InstallUtil.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeoutException;
 import org.eclipse.codewind.core.CodewindCorePlugin;
 import org.eclipse.codewind.core.internal.CodewindManager;
 import org.eclipse.codewind.core.internal.CodewindManager.InstallerStatus;
+import org.eclipse.codewind.core.internal.CoreUtil;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.ProcessHelper;
 import org.eclipse.codewind.core.internal.ProcessHelper.ProcessResult;
@@ -79,6 +80,23 @@ public class InstallUtil {
 	}
 	
 	public static ProcessResult startCodewind(String version, IProgressMonitor monitor) throws IOException, TimeoutException {
+		SubMonitor mon = SubMonitor.convert(monitor, 100);
+		ProcessResult result = doStartCodewind(version, mon.split(75));
+		IPreferenceStore prefs = CodewindCorePlugin.getDefault().getPreferenceStore();
+		if (prefs.getBoolean(CodewindCorePlugin.ENABLE_KEYRING_ACCESS) && result.getExitValue() != 0
+				&& "sec_keyring".equals(CLIUtil.getErrorKey(result))) {
+			// Ask the user if they want to disable keyring access and try again
+			if (CoreUtil.openConfirmDialog(Messages.StartFailForKeyringTitle, Messages.StartFailForKeyringMsg)) {
+				prefs.setValue(CodewindCorePlugin.ENABLE_KEYRING_ACCESS, false);
+				result = doStartCodewind(version, mon.split(25));
+			} else {
+				mon.setCanceled(true);
+			}
+		}
+		return result;	
+	}
+	
+	private static ProcessResult doStartCodewind(String version, IProgressMonitor monitor) throws IOException, TimeoutException {
 		SubMonitor mon = SubMonitor.convert(monitor, Messages.StartCodewindJobLabel, 100);
 		Process process = null;
 		try {

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
@@ -105,6 +105,9 @@ public class Messages extends NLS {
 	
 	public static String DebugPortNotifyTitle;
 	public static String DebugPortNotifyMsg;
+	
+	public static String StartFailForKeyringTitle;
+	public static String StartFailForKeyringMsg;
 
 	static {
 		// initialize resource bundle

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
@@ -98,3 +98,6 @@ UpgradeResultNotMigrated=Problems were encountered migrating these projects. Try
 
 DebugPortNotifyTitle=Debug port available for {0}
 DebugPortNotifyMsg=The debug port for {0} is now available: {1}
+
+StartFailForKeyringTitle=Keyring Not Available
+StartFailForKeyringMsg=Codewind did not start because the keyring could not be accessed. Do you want to disable Codewind keyring access? Projects that require image registries may not work if access is disabled. You can change the setting at any time in the Codewind preferences.

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -27,6 +27,7 @@ public class Messages extends NLS {
 
 	public static String PrefsParentPage_GeneralGroup;
 	public static String PrefsParentPage_AutoOpenOverviewButton;
+	public static String PrefsParentPage_EnableKeyring;
 	public static String PrefsParentPage_EnableSupportFeatures;
 	public static String PrefsParentPage_StartupShutdownGroup;
 	public static String PrefsParentPage_InstallTimeout;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -20,6 +20,7 @@ ConnectionPrefsPage_URLColumn=URL
 
 PrefsParentPage_GeneralGroup=&General Settings
 PrefsParentPage_AutoOpenOverviewButton=&Open overview page on project create and add
+PrefsParentPage_EnableKeyring=Enable Codewind &keyring access
 PrefsParentPage_EnableSupportFeatures=Enable support &features
 PrefsParentPage_StartupShutdownGroup=&Startup and Shutdown Settings
 PrefsParentPage_InstallTimeout=Codewind &install timeout (s):

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/CodewindPrefsParentPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/CodewindPrefsParentPage.java
@@ -141,6 +141,18 @@ public class CodewindPrefsParentPage extends PreferencePage implements IWorkbenc
 			}
 		});
 	    
+	    Button enableKeyringButton = new Button(generalGroup, SWT.CHECK);
+	    enableKeyringButton.setText(Messages.PrefsParentPage_EnableKeyring);
+	    enableKeyringButton.setLayoutData(new GridData(GridData.BEGINNING, GridData.FILL, false, false));
+	    enableKeyringButton.setSelection(prefs.getBoolean(CodewindCorePlugin.ENABLE_KEYRING_ACCESS));
+	    
+	    enableKeyringButton.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				prefs.setValue(CodewindCorePlugin.ENABLE_KEYRING_ACCESS, enableKeyringButton.getSelection());
+			}
+		});
+	    
 	    Button supportFeaturesButton = new Button(generalGroup, SWT.CHECK);
 	    supportFeaturesButton.setText(Messages.PrefsParentPage_EnableSupportFeatures);
 	    supportFeaturesButton.setLayoutData(new GridData(GridData.BEGINNING, GridData.FILL, false, false));


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [ ] Enhancement

## What does this PR do ?
Allows users to disable keyring access through a preference if they do not have keyring software installed or the keyring can't be accessed. If Codewind start fails because there is no keyring or it can't be accessed then the user is prompted at that time to disable keyring access so they can start Codewind.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2520

## Does this PR require a documentation change ?
Yes

## Any special notes for your reviewer ?
No