### PR TITLE
CW Issue #773: Add generic Codewind help to dialogs and wizards

### DIFF
--- a/dev/org.eclipse.codewind.ui/plugin.xml
+++ b/dev/org.eclipse.codewind.ui/plugin.xml
@@ -314,5 +314,9 @@
 	        <viewShortcut id="org.eclipse.codewind.ui.explorerView"/>
 		</perspectiveExtension> 
 	</extension>
+	
+	<extension point="org.eclipse.help.contexts">
+		<contexts file="xml/CodewindUIContexts.xml" plugin="org.eclipse.codewind.ui" />
+	</extension>
 
 </plugin>

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/CodewindUIPlugin.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/CodewindUIPlugin.java
@@ -34,6 +34,8 @@ public class CodewindUIPlugin extends AbstractUIPlugin {
 
 	// The plug-in ID
 	public static final String PLUGIN_ID = "org.eclipse.codewind.ui"; //$NON-NLS-1$
+	
+	public static String MAIN_CONTEXTID = PLUGIN_ID + ".codewindmain";
 
 	private static URL ICON_BASE_URL;
 	protected Map<String, ImageDescriptor> imageDescriptors = new HashMap<String, ImageDescriptor>();

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/RegistryManagementComposite.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/RegistryManagementComposite.java
@@ -227,6 +227,9 @@ public class RegistryManagementComposite extends Composite {
 			}
 		});
 		
+		// Add Context Sensitive Help
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, CodewindUIPlugin.MAIN_CONTEXTID);
+		
 		// Set the description text
 		String descText = supportsPushReg ? Messages.RegMgmtDescription : Messages.RegMgmtLocalDescription;
 		description.setText(descText);
@@ -242,6 +245,12 @@ public class RegistryManagementComposite extends Composite {
 		
 		createItems();
 		updateButtons();
+		regTable.setFocus();
+	}
+
+	@Override
+	public boolean setFocus() {
+		return regTable.setFocus();
 	}
 
 	private void createItems() {

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/RepositoryManagementComposite.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/RepositoryManagementComposite.java
@@ -254,13 +254,22 @@ public class RepositoryManagementComposite extends Composite {
 			}
 		});
 		
+		// Add Context Sensitive Help
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, CodewindUIPlugin.MAIN_CONTEXTID);
+		
 		if (repoViewer.getTable().getItemCount() > 0) {
 			repoViewer.getTable().setSelection(0);
 		}
 		updateDetails();
 		updateButtons();
+		repoViewer.getTable().setFocus();
 	}
 	
+	@Override
+	public boolean setFocus() {
+		return repoViewer.getTable().setFocus();
+	}
+
 	@Override
 	public void dispose() {
 		if (boldFont != null) {

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/CodewindConnectionComposite.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/CodewindConnectionComposite.java
@@ -113,6 +113,9 @@ public class CodewindConnectionComposite extends Composite {
 			}
 		});
 
+		// Add Context Sensitive Help
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, CodewindUIPlugin.MAIN_CONTEXTID);
+
         initialize();
         connNameText.setFocus();
 	}
@@ -140,6 +143,11 @@ public class CodewindConnectionComposite extends Composite {
 		return text;
 	}
 	
+	@Override
+	public boolean setFocus() {
+		return connNameText.setFocus();
+	}
+
 	private void initialize() {
 		if (connection != null) {
 			isUpdating = true;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ConnectionSelectionPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ConnectionSelectionPage.java
@@ -16,6 +16,7 @@ import java.util.List;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
 import org.eclipse.codewind.core.internal.connection.LocalConnection;
 import org.eclipse.codewind.core.internal.connection.RemoteConnection;
+import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.codewind.ui.internal.views.CodewindNavigatorLabelProvider;
 import org.eclipse.jface.viewers.ArrayContentProvider;
@@ -28,11 +29,13 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.PlatformUI;
 
 public class ConnectionSelectionPage extends WizardPage {
 	
 	private List<CodewindConnection> connections;
 	private CodewindConnection connection;
+	private TableViewer connViewer;
 
 	protected ConnectionSelectionPage(List<CodewindConnection> connections) {
 		super(Messages.SelectConnectionPageName);
@@ -52,7 +55,7 @@ public class ConnectionSelectionPage extends WizardPage {
 		GridData data = new GridData(GridData.FILL_HORIZONTAL);
 		composite.setLayoutData(data);
 		
-		TableViewer connViewer = new TableViewer(composite, SWT.BORDER | SWT.SINGLE | SWT.V_SCROLL);
+		connViewer = new TableViewer(composite, SWT.BORDER | SWT.SINGLE | SWT.V_SCROLL);
 		connViewer.setContentProvider(ArrayContentProvider.getInstance());
 		connViewer.setLabelProvider(new ConnLabelProvider());
 		connViewer.setInput(connections);
@@ -61,10 +64,21 @@ public class ConnectionSelectionPage extends WizardPage {
 			connection = (CodewindConnection)connViewer.getStructuredSelection().getFirstElement();
 			validate();
 		});
+		
+		// Add Context Sensitive Help
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(composite, CodewindUIPlugin.MAIN_CONTEXTID);
 
 		setControl(composite);
 	}
 	
+	@Override
+	public void setVisible(boolean visible) {
+		super.setVisible(visible);
+		if (visible) {
+			connViewer.getTable().setFocus();
+		}
+	}
+
 	private void validate() {
 		String errorMsg = null;
 		if (connection == null) {

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/LogLevelSelectionDialog.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/LogLevelSelectionDialog.java
@@ -30,6 +30,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.PlatformUI;
 
 public class LogLevelSelectionDialog extends TitleAreaDialog {
 
@@ -91,10 +92,15 @@ public class LogLevelSelectionDialog extends TitleAreaDialog {
 					selectedLevel = levelList.get(index);
 			}
 		});
+
+		// Add Context Sensitive Help
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(parent, CodewindUIPlugin.MAIN_CONTEXTID);
 		
 		if (currentLevel >= 0) {
 			logLevelCombo.select(currentLevel);
 		}
+		
+		logLevelCombo.setFocus();
 		
 		return composite;
 	}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindConnectionPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindConnectionPage.java
@@ -50,6 +50,14 @@ public class NewCodewindConnectionPage extends WizardPage implements CompositeCo
 		return canFinish();
 	}
 	
+	@Override
+	public void setVisible(boolean visible) {
+		super.setVisible(visible);
+		if (visible) {
+			composite.setFocus();
+		}
+	}
+
 	public boolean canFinish() {
 		return composite.canFinish();
 	}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectPage.java
@@ -28,6 +28,7 @@ import org.eclipse.codewind.core.internal.connection.RegistryInfo;
 import org.eclipse.codewind.core.internal.connection.RepositoryInfo;
 import org.eclipse.codewind.core.internal.constants.ProjectLanguage;
 import org.eclipse.codewind.core.internal.constants.ProjectType;
+import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.IDEUtil;
 import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.codewind.ui.internal.prefs.RegistryManagementDialog;
@@ -92,6 +93,9 @@ public class NewCodewindProjectPage extends WizardNewProjectCreationPage {
 		super.createControl(parent);
 		Composite composite = (Composite) getControl();
 		createContents(composite);
+		
+		// Add Context Sensitive Help
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(composite, CodewindUIPlugin.MAIN_CONTEXTID);
 	}
 
 	private void createContents(Composite parent) {
@@ -350,7 +354,7 @@ public class NewCodewindProjectPage extends WizardNewProjectCreationPage {
 		
 		initContent();
 	}
-	
+
 	protected boolean canFinish() {
 		return validate();
 	}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectDeployedDialog.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectDeployedDialog.java
@@ -27,6 +27,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.PlatformUI;
 
 public class ProjectDeployedDialog extends TitleAreaDialog {
 	
@@ -85,9 +86,13 @@ public class ProjectDeployedDialog extends TitleAreaDialog {
 		Button removeButton = addBehaviourButton(radioGroup, Messages.ProjectDeployedDialogRemoveLabel, Messages.ProjectDeployedDialogRemoveTooltip, Behaviour.REMOVE);
 		addBehaviourButton(radioGroup, Messages.ProjectDeployedDialogDisableLabel, Messages.ProjectDeployedDialogDisableTooltip, Behaviour.DISABLE);
 		addBehaviourButton(radioGroup, Messages.ProjectDeployedDialogMaintainLabel, Messages.ProjectDeployedDialogMaintainTooltip, Behaviour.MAINTAIN);
+
+		// Add Context Sensitive Help
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(parent, CodewindUIPlugin.MAIN_CONTEXTID);
 		
 		selectedBehaviour = Behaviour.REMOVE;
 		removeButton.setSelection(true);
+		removeButton.setFocus();
 		
 		return composite;
 	}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectSelectionPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectSelectionPage.java
@@ -13,6 +13,7 @@ package org.eclipse.codewind.ui.internal.wizards;
 
 import org.eclipse.codewind.core.internal.CoreUtil;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
+import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.IDEUtil;
 import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.core.resources.IProject;
@@ -38,6 +39,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.DirectoryDialog;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.SearchPattern;
 import org.eclipse.ui.model.WorkbenchContentProvider;
 import org.eclipse.ui.model.WorkbenchLabelProvider;
@@ -205,7 +207,10 @@ public class ProjectSelectionPage extends WizardPage {
 				validate();
 			}
 		});
-		
+
+		// Add Context Sensitive Help
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(composite, CodewindUIPlugin.MAIN_CONTEXTID);
+
 		if (hasValidProjects) {
 			workspaceProject.setSelection(true);
 			fileSystemProject.setSelection(false);
@@ -229,11 +234,22 @@ public class ProjectSelectionPage extends WizardPage {
 		if (hasValidProjects && workspaceProject.getSelection() && projectList.getTable().getItemCount() == 1) {
 			projectList.setChecked(projectList.getElementAt(0), true);
 		}
-
+		
 		validate();
 		setControl(composite);
 	}
 	
+	@Override
+	public void setVisible(boolean visible) {
+		super.setVisible(visible);
+		if (visible) {
+			if (workspaceProject.getSelection()) {
+				filterText.setFocus();
+			}
+			pathText.setFocus();
+		}
+	}
+
 	private boolean hasValidProjects() {
 		IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
 		for (IProject project : projects) {

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectTypeSelectionPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectTypeSelectionPage.java
@@ -28,6 +28,7 @@ import org.eclipse.codewind.core.internal.connection.RepositoryInfo;
 import org.eclipse.codewind.core.internal.constants.ProjectInfo;
 import org.eclipse.codewind.core.internal.constants.ProjectLanguage;
 import org.eclipse.codewind.core.internal.constants.ProjectType;
+import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.codewind.ui.internal.prefs.RepositoryManagementDialog;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -54,6 +55,7 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.PlatformUI;
 
 public class ProjectTypeSelectionPage extends WizardPage {
 
@@ -194,7 +196,10 @@ public class ProjectTypeSelectionPage extends WizardPage {
 				}
 			}
 		});
- 
+		
+		// Add Context Sensitive Help
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(composite, CodewindUIPlugin.MAIN_CONTEXTID);
+
 		// Don't show the subtype table by default, when updateTables is called it will decide
 		// whether to show it nor not
 		subtypeLabel.setVisible(false);
@@ -204,6 +209,14 @@ public class ProjectTypeSelectionPage extends WizardPage {
 		setControl(composite);
 	}
 	
+	@Override
+	public void setVisible(boolean visible) {
+		super.setVisible(visible);
+		if (visible) {
+			typeViewer.getTable().setFocus();
+		}
+	}
+
 	public boolean isActivePage() {
 		return isCurrentPage();
 	}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectValidationPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectValidationPage.java
@@ -21,6 +21,7 @@ import org.eclipse.codewind.core.internal.connection.CodewindConnection;
 import org.eclipse.codewind.core.internal.connection.ImagePushRegistryInfo;
 import org.eclipse.codewind.core.internal.connection.RegistryInfo;
 import org.eclipse.codewind.core.internal.constants.ProjectInfo;
+import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.IDEUtil;
 import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.codewind.ui.internal.prefs.RegistryManagementDialog;
@@ -167,8 +168,18 @@ public class ProjectValidationPage extends WizardPage {
 		
 		updatePage(false);
 
-		validateMsg.setFocus();
 		setControl(composite);
+		
+		// Add Context Sensitive Help
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(getControl(), CodewindUIPlugin.MAIN_CONTEXTID);
+	}
+
+	@Override
+	public void setVisible(boolean visible) {
+		super.setVisible(visible);
+		if (visible) {
+			validateMsg.setFocus();
+		}
 	}
 
 	@Override

--- a/dev/org.eclipse.codewind.ui/xml/CodewindUIContexts.xml
+++ b/dev/org.eclipse.codewind.ui/xml/CodewindUIContexts.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?NLS type="org.eclipse.help.contexts"?>
+<!--
+    Copyright (c) 2020 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v20.html
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<contexts>
+<context id="codewindmain">
+<description>
+<b>Container development unleashed</b>
+Codewind simplifies and enhances development in containers by extending industry standard IDEs with features to write, debug, and deploy cloud-native applications. Get started quickly with templates or samples, or pull in your applications and let Codewind get them cloud ready.
+</description>
+<topic href="https://www.eclipse.org/codewind/gettingstarted.html" label="Codewind Documentation"/>
+</context>
+</contexts>


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [ ] Enhancement

## What does this PR do ?
It creates a very general context help page with a link to open the Codewind Documentation and adds it to all dialogs and wizards. It also makes sure there is a widget in focus on all dialog and wizard pages since the context help does not work otherwise (this needed fixing anyway).

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/773

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No