### PR TITLE
CW Issue #2577: Make the base test case more flexible

### DIFF
--- a/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/AppsodyJavaMicroprofileAutoBuildTest.java
+++ b/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/AppsodyJavaMicroprofileAutoBuildTest.java
@@ -11,13 +11,11 @@
 
 package org.eclipse.codewind.test;
 
-import org.eclipse.codewind.core.internal.CodewindApplication;
 import org.eclipse.codewind.core.internal.constants.AppStatus;
-import org.eclipse.codewind.core.internal.constants.BuildStatus;
 import org.eclipse.codewind.test.util.CodewindUtil;
 import org.eclipse.core.runtime.IPath;
 
-public class AppsodyJavaMicroprofileAutoBuildTest extends BaseBuildTest {
+public class AppsodyJavaMicroprofileAutoBuildTest extends BaseAppsodyAutoBuildTest {
 
 	static {
 		projectName = "appsodyjavamicroprofileautobuildtest";
@@ -36,11 +34,11 @@ public class AppsodyJavaMicroprofileAutoBuildTest extends BaseBuildTest {
 		IPath destPath = project.getLocation();
 		destPath = destPath.append(srcPath);
 		copyFile("appsodyJavaMicroprofile/Hello.java", destPath);
-		refreshProject();
+		refreshProject(project);
     	
-		CodewindApplication app = connection.getAppByName(projectName);
-		CodewindUtil.waitForBuildState(app, BuildStatus.IN_PROGRESS, 30, 1);
-		assertTrue("Build should be successful", CodewindUtil.waitForBuildState(app, BuildStatus.SUCCESS, 300, 1));
-		assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppStatus.STARTED, 120, 1));
+		// No build states for Appsody, check that app goes into starting state
+		// (may not for some project types so don't do an assert)
+    	CodewindUtil.waitForAppState(app, AppStatus.STARTING, 15, 1);
+		assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppStatus.STARTED, 300, 1));
 	}
 }

--- a/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/AppsodyJavaSpringAutoBuildTest.java
+++ b/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/AppsodyJavaSpringAutoBuildTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,7 @@
 
 package org.eclipse.codewind.test;
 
-public class AppsodyJavaSpringAutoBuildTest extends BaseBuildTest {
+public class AppsodyJavaSpringAutoBuildTest extends BaseAppsodyAutoBuildTest {
 
 	static {
 		projectName = "appsodyjavaspringautobuildtest";

--- a/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/AppsodyNodeExpressAutoBuildTest.java
+++ b/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/AppsodyNodeExpressAutoBuildTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,7 @@
 
 package org.eclipse.codewind.test;
 
-public class AppsodyNodeExpressAutoBuildTest extends BaseBuildTest {
+public class AppsodyNodeExpressAutoBuildTest extends BaseAppsodyAutoBuildTest {
 
 	static {
 		projectName = "appsodynodeexpressautobuildtest";

--- a/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/BaseAutoBuildTest.java
+++ b/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/BaseAutoBuildTest.java
@@ -14,10 +14,12 @@ package org.eclipse.codewind.test;
 import java.net.URL;
 
 import org.eclipse.codewind.core.internal.CodewindApplication;
+import org.eclipse.codewind.core.internal.connection.CodewindConnection;
 import org.eclipse.codewind.core.internal.constants.AppStatus;
 import org.eclipse.codewind.core.internal.constants.BuildStatus;
 import org.eclipse.codewind.test.util.CodewindUtil;
 import org.eclipse.codewind.test.util.TestUtil;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -26,30 +28,54 @@ import org.junit.runners.MethodSorters;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public abstract class BaseAutoBuildTest extends BaseTest {
 	
+	protected static CodewindConnection conn;
+	protected static CodewindApplication app;
+	protected static IProject project;
+	
+	protected static String projectName;
+	protected static String projectType = null;
+	protected static String templateId;
+	protected static String relativeURL;
+	protected static String srcPath;
+	
 	protected static String text1, text2, text3;
 	protected static boolean extendedTest;
 	
+	protected void doSetup() throws Exception {
+        setup();
+        conn = getLocalConnection();
+        
+        app = createProject(conn, projectType, templateId, projectName);
+        if (projectType == null) {
+        	projectType = app.projectType.getId();
+        }
+        
+        // Wait for the project to be started
+        assertTrue("The application " + projectName + " should be running", CodewindUtil.waitForAppState(getApp(conn, projectName), AppStatus.STARTED, 600, 5));
+        
+        project = importProject(app);
+	}
+	
     @Test
     public void test01_doSetup() throws Exception {
-        TestUtil.print("Starting test: " + getName());
+    	TestUtil.print("Starting test: " + getName());
         doSetup();
     }
     
     @Test
     public void test02_checkApp() throws Exception {
-    	checkApp(text1);
+    	checkApp(app, relativeURL, text1);
     }
     
     @Test
     public void test03_checkDashboards() throws Exception {
-    	checkDashboards();
+    	checkDashboards(app);
     }
     
     @Test
     public void test04_disableAutoBuild() throws Exception {
-    	setAutoBuild(false);
+    	setAutoBuild(app, false);
     	// Some project types need to restart when auto build changes (node.js)
-    	CodewindApplication app = connection.getAppByName(projectName);
     	CodewindUtil.waitForAppState(app, AppStatus.STOPPING, 5, 1);
     	assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppStatus.STARTED, 120, 1));
     }
@@ -59,26 +85,24 @@ public abstract class BaseAutoBuildTest extends BaseTest {
     	IPath path = project.getLocation();
     	path = path.append(srcPath);
     	TestUtil.updateFile(path.toOSString(), text1, text2);
-    	refreshProject();
+    	refreshProject(project);
     	// Make sure the status doesn't change
-    	CodewindApplication app = connection.getAppByName(projectName);
     	CodewindUtil.checkStableAppStatus(app, AppStatus.STARTED, 5, 1);
     	// Check that the old text is still there
-    	pingApp(text1);
+    	pingApp(app, relativeURL, text1);
     	// Run a build
-    	build();
+    	build(app);
     	CodewindUtil.waitForBuildState(app, BuildStatus.IN_PROGRESS, 30, 1);
     	assertTrue("Build should be successful", CodewindUtil.waitForBuildState(app, BuildStatus.SUCCESS, 300, 1));
     	assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppStatus.STARTED, 120, 1));
     	// Check for the new text
-    	pingApp(text2);
+    	pingApp(app, relativeURL, text2);
     }
     
     @Test
     public void test06_enableAutoBuild() throws Exception {
-    	setAutoBuild(true);
+    	setAutoBuild(app, true);
     	// Some project types need to restart when auto build changes (node.js)
-    	CodewindApplication app = connection.getAppByName(projectName);
     	CodewindUtil.waitForAppState(app, AppStatus.STOPPING, 5, 1);
     	assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppStatus.STARTED, 120, 1));
     }
@@ -88,50 +112,51 @@ public abstract class BaseAutoBuildTest extends BaseTest {
     	IPath path = project.getLocation();
     	path = path.append(srcPath);
     	TestUtil.updateFile(path.toOSString(), text2, text3);
-    	refreshProject();
+    	refreshProject(project);
     	// Check that build is started automatically
-    	CodewindApplication app = connection.getAppByName(projectName);
     	CodewindUtil.waitForBuildState(app, BuildStatus.IN_PROGRESS, 30, 1);
     	assertTrue("Build should be successful", CodewindUtil.waitForBuildState(app, BuildStatus.SUCCESS, 300, 1));
     	assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppStatus.STARTED, 120, 1));
     	// Check for the new text
-    	pingApp(text3);
+    	pingApp(app, relativeURL, text3);
     }
     
     @Test
     public void test08_disableProject() throws Exception {
     	if (!extendedTest) return;
-    	URL appURL = getAppURL();
-    	disableProject();
-    	checkAppUnavailable(appURL);
+    	URL appURL = getAppURL(app, relativeURL);
+    	disableProject(app);
+    	checkAppUnavailable(projectName, appURL);
     }
     
     @Test
     public void test09_enableProject() throws Exception {
     	if (!extendedTest) return;
-    	enableProject();
-    	checkApp(text3);
+    	enableProject(app);
+    	checkApp(app, relativeURL, text3);
     }
     
     @Test
     public void test10_removeProject() throws Exception {
     	if (!extendedTest) return;
-    	URL appURL = getAppURL();
-    	removeProject();
-    	checkAppUnavailable(appURL);
+    	URL appURL = getAppURL(app, relativeURL);
+    	removeProject(app);
+    	checkAppUnavailable(projectName, appURL);
+    	app = null;
     }
     
     @Test
     public void test11_addProject() throws Exception {
     	if (!extendedTest) return;
-    	addProject();
-    	assertTrue("The application " + projectName + " should be running", CodewindUtil.waitForProjectStart(connection, projectName, 600, 5));
-    	checkApp(text3);
+    	app = addProject(project, projectType, conn);
+    	assertTrue("The application " + projectName + " should be running", CodewindUtil.waitForAppState(getApp(conn, projectName), AppStatus.STARTED, 600, 5));
+    	checkApp(app, relativeURL, text3);
     }
 
     @Test
     public void test99_tearDown() {
-    	doTearDown();
+    	cleanupConnection(conn);
+    	cleanup();
     	TestUtil.print("Ending test: " + getName());
     }
 

--- a/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/NodeAutoBuildTest.java
+++ b/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/NodeAutoBuildTest.java
@@ -11,7 +11,6 @@
 
 package org.eclipse.codewind.test;
 
-import org.eclipse.codewind.core.internal.CodewindApplication;
 import org.eclipse.codewind.core.internal.constants.AppStatus;
 import org.eclipse.codewind.core.internal.constants.BuildStatus;
 import org.eclipse.codewind.test.util.CodewindUtil;
@@ -41,9 +40,8 @@ public class NodeAutoBuildTest extends BaseAutoBuildTest {
 		IPath path = project.getLocation();
 		path = path.append(srcPath);
 		TestUtil.updateFile(path.toOSString(), origText, newText);
-		refreshProject();
+		refreshProject(project);
     	
-		CodewindApplication app = connection.getAppByName(projectName);
 		CodewindUtil.waitForBuildState(app, BuildStatus.IN_PROGRESS, 30, 1);
 		assertTrue("Build should be successful", CodewindUtil.waitForBuildState(app, BuildStatus.SUCCESS, 300, 1));
 		assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppStatus.STARTED, 120, 1));

--- a/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/NodeValidationTest.java
+++ b/dev/org.eclipse.codewind.test/src/org/eclipse/codewind/test/NodeValidationTest.java
@@ -11,7 +11,6 @@
 
 package org.eclipse.codewind.test;
 
-import org.eclipse.codewind.core.internal.CodewindApplication;
 import org.eclipse.codewind.core.internal.constants.AppStatus;
 import org.eclipse.codewind.test.util.CodewindUtil;
 import org.eclipse.codewind.test.util.TestUtil;
@@ -34,8 +33,7 @@ public class NodeValidationTest extends BaseValidationTest {
 		IPath path = project.getLocation();
     	path = path.append(srcPath);
 		TestUtil.updateFile(path.toOSString(), "// Add your code here", "app.get('/hello', (req, res) => res.send('Hello World!'));");
-		build();
-		CodewindApplication app = connection.getAppByName(projectName);
+		build(app);
 		// For Java builds the states can go by quickly so don't do an assert on this
 		CodewindUtil.waitForAppState(app, AppStatus.STOPPED, 120, 1);
 		assertTrue("App should be in started state", CodewindUtil.waitForAppState(app, AppStatus.STARTED, 300, 1));


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
- Makes the base test case more flexible so that tests can have more than one connection and/or application.
- Cleaned up the Appsody tests to not check for build states.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2577

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No