### PR TITLE
CW Issue #2601: Cleanup if create or bind project times out 0.11.0

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -180,6 +180,7 @@ public class Messages extends NLS {
 	public static String BindProjectWizardDisableTask;
 	public static String BindProjectWizardJobLabel;
 	public static String BindProjectWizardError;
+	public static String BindProjectWizardTimeout;
 	
 	public static String SelectConnectionPageName;
 	public static String SelectConnectionPageTitle;
@@ -188,6 +189,7 @@ public class Messages extends NLS {
 	
 	public static String MoveProjectJobLabel;
 	public static String MoveProjectError;
+	public static String MoveProjectTimeout;
 	
 	public static String ProjectDeployedDialogShell;
 	public static String ProjectDeployedDialogTitle;
@@ -386,12 +388,17 @@ public class Messages extends NLS {
 	public static String NewProjectPage_CreateJobLabel;
 	public static String NewProjectPage_ProjectCreateErrorTitle;
 	public static String NewProjectPage_ProjectCreateErrorMsg;
+	public static String NewProjectPage_ProjectCreateTimeoutMsg;
 	public static String NewProjectPage_CodewindConnectError;
 	public static String NewProjectPage_TemplateListError;
 	public static String NewProjectPage_EmptyTemplateList;
 	public static String NewProjectPage_NoLocationError;
 	public static String NewProjectPage_NoTemplateSelected;
 	public static String ProjectLocationInCodewindDataDirError;
+	
+	public static String ProjectCleanupJobLabel;
+	public static String ProjectCleanupError;
+	public static String DirectoryCleanupError;
 	
 	public static String ManageRegistriesLinkLabel;
 	public static String ManageRegistriesLinkText;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -137,6 +137,7 @@ BindProjectWizardRemoveTask=Removing existing deployments
 BindProjectWizardDisableTask=Disabling existing deployments
 BindProjectWizardJobLabel=Adding project to {0}: {1}
 BindProjectWizardError=An error occurred trying to add the {0} project to Codewind.
+BindProjectWizardTimeout=A timeout occurred trying to add the {0} project to Codewind. If Codewind is performing other tasks, wait until they are finished and try again.
 
 SelectConnectionPageName=Select Connection
 SelectConnectionPageTitle=Select a Connection
@@ -145,6 +146,7 @@ SelectConnectionPageNoSelectionMsg=Select a connection from the list.
 
 MoveProjectJobLabel=Moving project to {0}: {1}
 MoveProjectError=An error occurred while moving the {0} project from {1} to {2}.
+MoveProjectTimeout=A timeout occurred while moving the {0} project from {1} to {2}. If Codewind is performing other tasks, wait until they are finished and try again.
 
 ProjectDeployedDialogShell=Manage Deployments
 ProjectDeployedDialogTitle=Project Already Deployed
@@ -380,12 +382,17 @@ NewProjectPage_InvalidProjectName=The project name contains invalid characters. 
 NewProjectPage_CreateJobLabel=Creating Codewind project: {0}
 NewProjectPage_ProjectCreateErrorTitle=Project Create Error
 NewProjectPage_ProjectCreateErrorMsg=An error occurred trying to create Codewind project {0}
+NewProjectPage_ProjectCreateTimeoutMsg=A timeout occurred trying to create Codewind project {0}. If Codewind is performing other tasks, wait until they are finished and try again.
 NewProjectPage_CodewindConnectError=Could not connect to Codewind. Check logs for more information.
 NewProjectPage_TemplateListError=Could not get the list of templates. Check logs for more information.
 NewProjectPage_EmptyTemplateList=There are no available templates. Use the Manage Template Sources link to configure template sources and control the templates shown.
 NewProjectPage_NoLocationError=Specify a location for the project.
 NewProjectPage_NoTemplateSelected=Select a template to use for the new project.
 ProjectLocationInCodewindDataDirError=Projects cannot be located in the {0} folder. This is where Codewind user configuration files are kept.
+
+ProjectCleanupJobLabel=Cleaning up project: {0}
+ProjectCleanupError=An error occurred trying to clean up project: {0}
+DirectoryCleanupError=An error occurred trying to clean up the directory: {0}. Try removing the directory manually.
 
 ManageRegistriesLinkLabel=Add re&gistries for your project:
 ManageRegistriesLinkText=Manage Container Registries...

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectWizard.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectWizard.java
@@ -11,13 +11,16 @@
 
 package org.eclipse.codewind.ui.internal.wizards;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 
 import org.eclipse.codewind.core.CodewindCorePlugin;
 import org.eclipse.codewind.core.internal.CodewindApplication;
 import org.eclipse.codewind.core.internal.CodewindManager;
 import org.eclipse.codewind.core.internal.CodewindManager.InstallerStatus;
 import org.eclipse.codewind.core.internal.CoreUtil;
+import org.eclipse.codewind.core.internal.FileUtil;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.cli.ProjectUtil;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
@@ -172,10 +175,12 @@ public class NewCodewindProjectWizard extends Wizard implements INewWizard {
 					// Create and bind the project
 					ProjectUtil.createProject(projectName, projectPath.toOSString(), info.getUrl(), connection.getConid(), mon.split(40));
 					if (mon.isCanceled()) {
+						cleanup(projectName, projectPath, connection);
 						return Status.CANCEL_STATUS;
 					}
 					ProjectUtil.bindProject(projectName, projectPath.toOSString(), info.getLanguage(), info.getProjectType(), connection.getConid(), mon.split(40));
 					if (mon.isCanceled()) {
+						cleanup(projectName, projectPath, connection);
 						return Status.CANCEL_STATUS;
 					}
 					mon.split(10);
@@ -198,6 +203,10 @@ public class NewCodewindProjectWizard extends Wizard implements INewWizard {
 					ViewHelper.openCodewindExplorerView();
 					CodewindUIPlugin.getUpdateHandler().updateConnection(connection);
 					return Status.OK_STATUS;
+				} catch (TimeoutException e) {
+					Logger.logError("A timeout occurred trying to create a project with type: " + info.getUrl() + ", and name: " + projectName, e); //$NON-NLS-1$ //$NON-NLS-2$
+					cleanup(projectName, projectPath, connection);
+					return new Status(IStatus.ERROR, CodewindUIPlugin.PLUGIN_ID, NLS.bind(Messages.NewProjectPage_ProjectCreateTimeoutMsg, projectName), e);
 				} catch (Exception e) {
 					Logger.logError("An error occured trying to create a project with type: " + info.getUrl() + ", and name: " + projectName, e); //$NON-NLS-1$ //$NON-NLS-2$
 					return new Status(IStatus.ERROR, CodewindUIPlugin.PLUGIN_ID, NLS.bind(Messages.NewProjectPage_ProjectCreateErrorMsg, projectName), e);
@@ -208,6 +217,49 @@ public class NewCodewindProjectWizard extends Wizard implements INewWizard {
 		return true;
 	}
 	
+	private void cleanup(String projectName, IPath projectPath, CodewindConnection connection) {
+		Job job = new Job(NLS.bind(Messages.ProjectCleanupJobLabel, projectName)) {
+			@Override
+			protected IStatus run(IProgressMonitor monitor) {
+				SubMonitor mon = SubMonitor.convert(monitor, 30);
+				mon.split(10);
+				connection.refreshApps(null);
+				CodewindApplication app = connection.getAppByName(projectName);
+				if (app != null) {
+					try {
+						ProjectUtil.removeProject(app.name, app.projectID, true, mon.split(20));
+					} catch (Exception e) {
+						Logger.logError("An error occurred while trying to remove the project after project create terminated for: " + projectName, e);
+						return new Status(IStatus.ERROR, CodewindUIPlugin.PLUGIN_ID, NLS.bind(Messages.ProjectCleanupError, projectName), null);
+					}
+				} else {
+					mon.split(20);
+					boolean success = false;
+					for (int i = 0; i < 10 && !success; i++) {
+						try {
+							FileUtil.deleteDirectory(projectPath.toOSString(), true);
+							success = true;
+						} catch (IOException e) {
+							mon.worked(10);
+							mon.setWorkRemaining(20);
+							try {
+								Thread.sleep(1000);
+							} catch (InterruptedException e1) {
+								// Ignore
+							}
+						}
+					}
+					if (!success) {
+						Logger.logError("An error occurred while trying to cleanup the project directory after project create terminated: " + projectPath.toOSString());
+						return new Status(IStatus.ERROR, CodewindUIPlugin.PLUGIN_ID, NLS.bind(Messages.DirectoryCleanupError, projectPath.toOSString()), null);
+					}
+				}
+				return Status.OK_STATUS;
+			}
+		};
+		job.schedule();
+	}
+
 	private boolean checkInstallStatus() {
 		// If the installer is currently running, show a dialog to the user
 		final InstallerStatus installerStatus = CodewindManager.getManager().getInstallerStatus();


### PR DESCRIPTION
## What does this PR do ?
Attempts to clean up if project create or bind times out or is canceled.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2601

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No