### PR TITLE
CW Issue #2675: Open editor first so view does not take up entire window - 0.11.0

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/GetStartedAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/GetStartedAction.java
@@ -11,9 +11,14 @@
 
 package org.eclipse.codewind.ui.internal.actions;
 
+import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.codewind.ui.internal.views.ViewHelper;
 import org.eclipse.jface.action.Action;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.intro.IIntroManager;
 import org.eclipse.ui.intro.IIntroPart;
@@ -33,12 +38,30 @@ public class GetStartedAction extends Action {
 			manager.closeIntro(introPart);
 		}
 		
+		// Open the J2EE perspective
+		try {
+			IWorkbench workbench = PlatformUI.getWorkbench();
+			workbench.showPerspective("org.eclipse.jst.j2ee.J2EEPerspective", workbench.getActiveWorkbenchWindow());
+		} catch (Exception e) {
+			Logger.logError("An error occurred trying to open the J2EE perspective", e);
+		}
+
+		// Open the Codewind welcome page
+		IEditorPart part = OpenWelcomePageAction.openWelcomePage();
+
 		// Open the Codewind Explorer view
 		ViewHelper.openCodewindExplorerViewNoExec();
-		
-		// Open the Codewind welcome page
-		// Make sure this done last so that it has focus
-		OpenWelcomePageAction.openWelcomePage();
+
+		// Make the welcome page the focus
+		if (part != null) {
+			IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+			if (window != null) {
+				IWorkbenchPage page = window.getActivePage();
+				if (page != null) {
+					page.activate(part);
+				}
+			}
+		}
 	}
 
 }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/OpenWelcomePageAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/OpenWelcomePageAction.java
@@ -52,19 +52,23 @@ public class OpenWelcomePageAction extends SelectionProviderAction {
 		openWelcomePage();
 	}
 
-	public static void openWelcomePage() {
+	public static IEditorPart openWelcomePage() {
 		IWorkbenchWindow workbenchWindow = CodewindUIPlugin.getDefault().getWorkbench().getActiveWorkbenchWindow();
 		IWorkbenchPage page = workbenchWindow.getActivePage();
+		IEditorPart editorPart = null;
 
 		try {
 			WelcomePageEditorInput input = new WelcomePageEditorInput();
-			IEditorPart editorPart = page.openEditor(input, WelcomePageEditorInput.EDITOR_ID);
+			editorPart = page.openEditor(input, WelcomePageEditorInput.EDITOR_ID);
 			if (!(editorPart instanceof WelcomePageEditorPart)) {
 				// This should not happen
 				Logger.logError("Welcome page editor part is the wrong type: " + editorPart.getClass()); //$NON-NLS-1$
+				editorPart = null;
 			}
 		} catch (Exception e) {
 			Logger.logError("An error occurred opening the welcome page editor", e); //$NON-NLS-1$
 		}
+		
+		return editorPart;
 	}
 }


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
- Opens the editor first so the view does not take up the entire window. Sets the editor as the active part after opening the view.
- Makes sure the J2EE perspective is open (in case the user was in a different perspective before installing Codewind)

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2675

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No