### PR TITLE
CW Issue #2704: Fix radio button problem with project selection page

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectSelectionPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectSelectionPage.java
@@ -245,8 +245,9 @@ public class ProjectSelectionPage extends WizardPage {
 		if (visible) {
 			if (workspaceProject.getSelection()) {
 				filterText.setFocus();
+			} else {
+				pathText.setFocus();
 			}
-			pathText.setFocus();
 		}
 	}
 


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Fixes a problem with the radio button behaviour in the project selection page. If the user chose to select a project from the file system and used the browse button to select the project folder, the radio button would switch back to selecting the project from the workspace.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2704

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No