### PR TITLE
CW Issue #2790: Fix various issues with debug

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
@@ -121,16 +121,6 @@ public class CodewindEclipseApplication extends CodewindApplication {
 					Logger.logError("An error occurred while disconnecting the debugger for project: " + name, e); //$NON-NLS-1$
 				}
 			}
-			ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
-			launchManager.removeLaunch(launch);
-			ILaunchConfiguration launchConfig = launch.getLaunchConfiguration();
-			if (launchConfig != null) {
-				try {
-					launchConfig.delete();
-				} catch (CoreException e) {
-					Logger.logError("An error occurred while deleting the launch configuration for project: " + name, e); //$NON-NLS-1$
-				}
-			}
 		}
 		setLaunch(null);
 	}

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/KubeUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/KubeUtil.java
@@ -101,11 +101,6 @@ public class KubeUtil {
 			if (!pfInfo.launch.isTerminated()) {
 				pfInfo.launch.terminate();
 			}
-			DebugPlugin.getDefault().getLaunchManager().removeLaunch(pfInfo.launch);
-			ILaunchConfiguration launchConfig = pfInfo.launch.getLaunchConfiguration();
-			if (launchConfig != null) {
-				launchConfig.delete();
-			}
 		}
 	}
 	

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/RemoteEclipseApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/RemoteEclipseApplication.java
@@ -73,11 +73,12 @@ public class RemoteEclipseApplication extends CodewindEclipseApplication {
 	
 	private void cleanupPortForwarding() {
 		if (debugPFInfo != null) {
+			Logger.log("Ending port forwarding for the " + name + " application: " + debugPFInfo.localPort + ":" + debugPFInfo.remotePort); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			
 			// Clear out the port forwarding info to indicate that it was ended internally
 			PortForwardInfo info = debugPFInfo;
 			debugPFInfo = null;
 			try {
-				Logger.log("Ending port forwarding for the " + name + " application: " + debugPFInfo.localPort + ":" + debugPFInfo.remotePort); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 				KubeUtil.endPortForward(this, info);
 			} catch (Exception e) {
 				Logger.logError("An error occurred trying to terminate the debug port forward for: " + name, e); //$NON-NLS-1$

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/launch/CodewindLaunchConfigDelegate.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/launch/CodewindLaunchConfigDelegate.java
@@ -73,10 +73,8 @@ public class CodewindLaunchConfigDelegate extends AbstractJavaLaunchConfiguratio
 			if (debugTarget != null) {
 				Logger.log("Debugger connect success. Application should go into Debugging state soon."); //$NON-NLS-1$
 				launch.addDebugTarget(debugTarget);
-			}
-			else {
+			} else if (!monitor.isCanceled()) {
 				Logger.logError("Debugger connect failure"); //$NON-NLS-1$
-
 				CoreUtil.openDialog(true,
 						Messages.DebuggerConnectFailureDialogTitle,
 						Messages.DebuggerConnectFailureDialogMsg);


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

- Don't clear out the launches on terminate so that the user can still look at the console for the launch in case there is a problem
- Don't show the timeout message dialog if the user canceled the debug connect
- Also fixed an NPE in port forward logging


## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2790

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No