### PR TITLE
CW Issue #1579/2851: Add a collect diagnostics action

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/CLIUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/cli/CLIUtil.java
@@ -81,6 +81,18 @@ public class CLIUtil {
 	}
 	
 	public static Process runCWCTL(String[] globalOptions, String[] cmd, String[] options, String[] args) throws IOException {
+		String[] command = getCWCTLCommand(globalOptions, cmd, options, args);
+		ProcessBuilder builder = new ProcessBuilder(command);
+		if (PlatformUtil.getOS() == PlatformUtil.OperatingSystem.MAC) {
+			String pathVar = System.getenv("PATH");
+			pathVar = "/usr/local/bin:" + pathVar;
+			Map<String, String> env = builder.environment();
+			env.put("PATH", pathVar);
+		}
+		return builder.start();
+	}
+	
+	public static List<String> getCWCTLCommandList(String[] globalOptions, String[] cmd, String[] options, String[] args) throws IOException {
 		// Make sure the executables are installed
 		for (int i=0; i< cliInfos.length; i++) {
 			if (cliInfos[i] != null)
@@ -93,15 +105,12 @@ public class CLIUtil {
 		addOptions(cmdList, cmd);
 		addOptions(cmdList, options);
 		addOptions(cmdList, args);
-		String[] command = cmdList.toArray(new String[cmdList.size()]);
-		ProcessBuilder builder = new ProcessBuilder(command);
-		if (PlatformUtil.getOS() == PlatformUtil.OperatingSystem.MAC) {
-			String pathVar = System.getenv("PATH");
-			pathVar = "/usr/local/bin:" + pathVar;
-			Map<String, String> env = builder.environment();
-			env.put("PATH", pathVar);
-		}
-		return builder.start();
+		return cmdList;
+	}
+	
+	public static String[] getCWCTLCommand(String[] globalOptions, String[] cmd, String[] options, String[] args) throws IOException {
+		List<String> cmdList = getCWCTLCommandList(globalOptions, cmd, options, args);
+		return cmdList.toArray(new String[cmdList.size()]);
 	}
 	
 	private static void addOptions(List<String> cmdList, String[] options) {

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/launch/UtilityLaunchConfigDelegate.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/launch/UtilityLaunchConfigDelegate.java
@@ -24,6 +24,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.model.IProcess;
@@ -43,6 +44,7 @@ public class UtilityLaunchConfigDelegate extends LaunchConfigurationDelegate {
 			throws CoreException {
 
 		String[] command = new String[0];
+		SubMonitor mon = SubMonitor.convert(monitor, 100);
 
 		try {
 			List<String> commandList = config.getAttribute(COMMAND_ATTR, (List<String>) null);
@@ -53,14 +55,17 @@ public class UtilityLaunchConfigDelegate extends LaunchConfigurationDelegate {
 			}
 			command = commandList.toArray(new String[commandList.size()]);
 			String title = config.getAttribute(TITLE_ATTR, (String) null);
+			mon.worked(30);
 
 			ProcessBuilder builder = new ProcessBuilder(command);
 			Process p = builder.start();
+			mon.worked(30);
 
 			Map<String, String> attributes = new HashMap<String, String>();
 			attributes.put(IProcess.ATTR_PROCESS_TYPE, "codewind.utility");
 			IProcess process = new RuntimeProcess(launch, p, title, attributes);
 			launch.addProcess(process);
+			mon.worked(40);
 		} catch (Exception e) {
 			monitor.setCanceled(true);
 			DebugPlugin.getDefault().getLaunchManager().removeLaunch(launch);

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
@@ -116,12 +116,13 @@ public class Messages extends NLS {
 	public static String ErrorNoKubectlMsg;
 	
 	public static String UtilityLaunchError;
+	public static String UtilGenDiagnosticsTitle;
 	
 	public static String PortForwardTitle;
 	public static String PortForwardTerminateTitle;
 	public static String PortForwardTerminateMsg;
 	public static String PortForwardTerminateToggleMsg;
-
+	
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
@@ -109,9 +109,13 @@ DebugPortNotifyMsg=The local debug port for {0} is now available: {1}
 ErrorNoKubectlMsg=Neither of the kubectl or oc commands could be found on the path. Make sure one of them is installed.
 
 UtilityLaunchError=An error occurred trying to launch: {0}
+UtilGenDiagnosticsTitle=Collect diagnostics
 
 PortForwardTitle=Port forward {0}
 PortForwardTerminateTitle=Port Forwarding Terminated
 PortForwardTerminateMsg=Port forwarding has terminated for application {0} ({1}) and port {2}. Anything that was depending on this such as a debug session will also terminate.
 PortForwardTerminateToggleMsg=Don't show this message again
+
+
+
 

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/IDEUtil.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/IDEUtil.java
@@ -13,7 +13,9 @@ package org.eclipse.codewind.ui.internal;
 
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
@@ -22,6 +24,9 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.model.IProcess;
+import org.eclipse.ui.console.IConsole;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
@@ -35,6 +40,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.browser.IWebBrowser;
 import org.eclipse.ui.browser.IWorkbenchBrowserSupport;
+import org.eclipse.ui.console.ConsolePlugin;
 
 public class IDEUtil {
 	
@@ -149,5 +155,13 @@ public class IDEUtil {
 			Logger.logError("An error occurred trying to open an external browser at: " + urlStr, e); //$NON-NLS-1$
 		}
 	}
-
+	
+	// Find the first console that matches a process in the launch
+	public static Optional<IConsole> getConsoleForLaunch(ILaunch launch) {
+		List<IProcess> processes = Arrays.asList(launch.getProcesses());
+		return Arrays.stream(ConsolePlugin.getDefault().getConsoleManager().getConsoles())
+				.filter(console -> console instanceof org.eclipse.debug.ui.console.IConsole
+						&& processes.contains(((org.eclipse.debug.ui.console.IConsole) console).getProcess()))
+				.findFirst();
+	}
 }

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/DiagnosticsAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/DiagnosticsAction.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *	 IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.codewind.ui.internal.actions;
+
+import java.util.Optional;
+
+import org.eclipse.codewind.core.CodewindCorePlugin;
+import org.eclipse.codewind.core.internal.Logger;
+import org.eclipse.codewind.core.internal.cli.OtherUtil;
+import org.eclipse.codewind.core.internal.connection.CodewindConnection;
+import org.eclipse.codewind.ui.CodewindUIPlugin;
+import org.eclipse.codewind.ui.internal.IDEUtil;
+import org.eclipse.codewind.ui.internal.messages.Messages;
+import org.eclipse.codewind.ui.internal.wizards.DiagnosticsDialog;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.jface.viewers.ISelectionProvider;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.actions.SelectionProviderAction;
+import org.eclipse.ui.console.IConsole;
+import org.eclipse.ui.console.IConsoleConstants;
+import org.eclipse.ui.console.IConsoleView;
+
+/**
+ * Action for collecting Codewind diagnostics
+ */
+public class DiagnosticsAction extends SelectionProviderAction {
+	
+	private CodewindConnection conn;
+	
+	public DiagnosticsAction(ISelectionProvider selectionProvider) {
+		super(selectionProvider, Messages.DiagnosticsActionLabel);
+		selectionChanged(getStructuredSelection());
+	}
+
+	@Override
+	public void selectionChanged(IStructuredSelection sel) {
+		if (sel.size() == 1) {
+			Object obj = sel.getFirstElement();
+			if (obj instanceof CodewindConnection) {
+				conn = (CodewindConnection)obj;
+				setEnabled(conn.isConnected());
+				return;
+			}
+		}
+		setEnabled(false);
+	}
+
+	@Override
+	public void run() {
+		if (conn == null) {
+			// should not be possible
+			Logger.logError("DiagnosticsAction ran but no connection was selected"); //$NON-NLS-1$
+			return;
+		}
+		
+		DiagnosticsDialog dialog = new DiagnosticsDialog(Display.getDefault().getActiveShell(), conn);
+		if (dialog.open() == IStatus.OK) {
+			Job job = new Job(NLS.bind(Messages.DiagnosticsActionJobLabel, conn.getName())) {
+    			@Override
+    			protected IStatus run(IProgressMonitor monitor) {
+    				try {
+    					SubMonitor mon = SubMonitor.convert(monitor, NLS.bind(Messages.DiagnosticsActionJobLabel, conn.getName()), 100);
+    					ILaunch launch = OtherUtil.startDiagnostics(conn.getName(), conn.getConid(), dialog.includeEclipseWorkspace(), dialog.includeProjectInfo(), mon.split(70));
+    					Optional<IConsole> consoleResult = IDEUtil.getConsoleForLaunch(launch);
+    					while(!mon.isCanceled() && !launch.isTerminated() && !consoleResult.isPresent()) {
+    						try {
+								Thread.sleep(200);
+							} catch (Exception e) {
+								// Ignore
+							}
+    						mon.worked(10);
+    						mon.setWorkRemaining(30);
+    						consoleResult = IDEUtil.getConsoleForLaunch(launch);
+    					}
+    					if (mon.isCanceled()) {
+    						return Status.CANCEL_STATUS;
+    					}
+    					if (consoleResult.isPresent()) {
+    						final IConsole console = consoleResult.get();
+    						Display.getDefault().asyncExec(() -> {
+	    						IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+	    						IWorkbenchPage page = window == null ? null : window.getActivePage();
+	    						if (page != null) {
+	    							try {
+	    								IConsoleView view = (IConsoleView) page.showView(IConsoleConstants.ID_CONSOLE_VIEW);
+	    								view.display(console);
+	    							} catch (Exception e) {
+	    								Logger.logError("An error occurred trying to open the console view", e); //$NON-NLS-1$
+	    							}
+	    						}
+    						});
+    					} else {
+    						Logger.logError("Could not find the console for launch: " + launch); //$NON-NLS-1$
+    					}
+    				} catch (Exception e) {
+    					Logger.logError("An error occurred trying to generate diagnostics for connection: " + conn.getName(), e); //$NON-NLS-1$
+    					return new Status(IStatus.ERROR, CodewindUIPlugin.PLUGIN_ID, NLS.bind(Messages.DiagnosticsErrorMsg, conn.getName()), e);
+    				}
+    				return Status.OK_STATUS;
+    			}
+    		};
+    		job.schedule();
+			
+		}
+	}
+
+	public boolean showAction() {
+		return conn != null && CodewindCorePlugin.getDefault().getPreferenceStore().getBoolean(CodewindCorePlugin.ENABLE_SUPPORT_FEATURES);
+	}
+}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/LocalConnectionActionProvider.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/LocalConnectionActionProvider.java
@@ -36,6 +36,7 @@ public class LocalConnectionActionProvider extends CommonActionProvider {
 	private ManageReposAction manageReposAction;
 	private LocalDoubleClickAction doubleClickAction;
 	private LogLevelAction logLevelAction;
+	private DiagnosticsAction diagnosticsAction;
 	
     @Override
     public void init(ICommonActionExtensionSite aSite) {
@@ -49,6 +50,7 @@ public class LocalConnectionActionProvider extends CommonActionProvider {
         startStopAction = new InstallerAction(ActionType.START_STOP, selProvider);
         doubleClickAction = new LocalDoubleClickAction(selProvider);
         logLevelAction = new LogLevelAction(selProvider);
+        diagnosticsAction = new DiagnosticsAction(selProvider);
     }
     
 	@Override
@@ -69,9 +71,17 @@ public class LocalConnectionActionProvider extends CommonActionProvider {
 		if (status.isInstalled()) {
 			menu.add(startStopAction);
 		}
+		boolean supportSeparator = false;
 		if (logLevelAction.showAction()) {
 			menu.add(new Separator());
+			supportSeparator = true;
 			menu.add(logLevelAction);
+		}
+		if (diagnosticsAction.showAction()) {
+			if (!supportSeparator) {
+				menu.add(new Separator());
+			}
+			menu.add(diagnosticsAction);
 		}
 	}
 

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RemoteConnectionActionProvider.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/RemoteConnectionActionProvider.java
@@ -39,6 +39,7 @@ public class RemoteConnectionActionProvider extends CommonActionProvider {
 	private RemoteDoubleClickAction remoteDoubleClickAction;
 	private OpenTektonDashboardAction openTektonDashboardAction;
 	private LogLevelAction logLevelAction;
+	private DiagnosticsAction diagnosticsAction;
 	
 	@Override
 	public void init(ICommonActionExtensionSite aSite) {
@@ -54,6 +55,7 @@ public class RemoteConnectionActionProvider extends CommonActionProvider {
 		remoteDoubleClickAction = new RemoteDoubleClickAction(selProvider);
 		openTektonDashboardAction = new OpenTektonDashboardAction(selProvider);
 		logLevelAction = new LogLevelAction(selProvider);
+		diagnosticsAction = new DiagnosticsAction(selProvider);
 	}
 	
 	@Override
@@ -72,9 +74,17 @@ public class RemoteConnectionActionProvider extends CommonActionProvider {
 		menu.add(connectDisconnectAction);
 		menu.add(editConnectionAction);
 		menu.add(removeConnectionAction);
+		boolean supportSeparator = false;
 		if (logLevelAction.showAction()) {
 			menu.add(new Separator());
+			supportSeparator = true;
 			menu.add(logLevelAction);
+		}
+		if (diagnosticsAction.showAction()) {
+			if (!supportSeparator) {
+				menu.add(new Separator());
+			}
+			menu.add(diagnosticsAction);
 		}
 	}
     

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -611,6 +611,19 @@ public class Messages extends NLS {
 	public static String WelcomePageLearnExtensionsOpenAPITooltip;
 	public static String WelcomePageLearnExtensionsDockerLink;
 	public static String WelcomePageLearnExtensionsDockerTooltip;
+	
+	public static String DiagnosticsActionLabel;
+	public static String DiagnosticsActionJobLabel;
+	public static String DiagnosticsErrorMsg;
+	public static String DiagnosticsDialogShell;
+	public static String DiagnosticsDialogTitle;
+	public static String DiagnosticsDialogMsg;
+	public static String DiagnosticsDialogAdditionalInfoText;
+	public static String DiagnosticsDialogAdditionalInfoGroup;
+	public static String DiagnosticsDialogEclipseWorkspaceButton;
+	public static String DiagnosticsDialogProjectInfoButton;
+	public static String DiagnosticsDialogSelectAllButton;
+	public static String DiagnosticsDialogClearAllButton;
 
 	static {
 		// initialize resource bundle

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -605,3 +605,16 @@ WelcomePageLearnExtensionsOpenAPILink=Codewind OpenAPI Tools
 WelcomePageLearnExtensionsOpenAPITooltip=Open the Codewind OpenAPI Tools marketplace page in a browser
 WelcomePageLearnExtensionsDockerLink=Eclipse Docker Tooling
 WelcomePageLearnExtensionsDockerTooltip=Open the Eclipse Docker Tooling marketplace page in a browser
+
+DiagnosticsActionLabel=Collect Diagnostics
+DiagnosticsActionJobLabel=Launch diagnostics collection for: {0}
+DiagnosticsErrorMsg=An error occurred trying to collect diagnostics for the {0} connection.
+DiagnosticsDialogShell=Collect Diagnostics
+DiagnosticsDialogTitle=Collect Diagnostics for Connection: {0}
+DiagnosticsDialogMsg=Identify additional information to include in the diagnostics
+DiagnosticsDialogAdditionalInfoText=Information such as the Codewind logs are included in the diagnostics by default. Select any additional information to include in the diagnostics below.
+DiagnosticsDialogAdditionalInfoGroup=Additional diagnostic information
+DiagnosticsDialogEclipseWorkspaceButton=Eclipse &workspace log
+DiagnosticsDialogProjectInfoButton=&Project information
+DiagnosticsDialogSelectAllButton=&Select all
+DiagnosticsDialogClearAllButton=&Clear all

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/DiagnosticsDialog.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/DiagnosticsDialog.java
@@ -1,0 +1,184 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *	 IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.codewind.ui.internal.wizards;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.codewind.core.internal.connection.CodewindConnection;
+import org.eclipse.codewind.ui.CodewindUIPlugin;
+import org.eclipse.codewind.ui.internal.IDEUtil;
+import org.eclipse.codewind.ui.internal.messages.Messages;
+import org.eclipse.jface.dialogs.TitleAreaDialog;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.PlatformUI;
+
+public class DiagnosticsDialog extends TitleAreaDialog {
+
+	private final CodewindConnection conn;
+	private boolean includeEclipseWorkspace, includeProjectInfo;
+	private Button eclipseWorkspaceButton, projectInfoButton;
+	private List<Button> includeButtons = new ArrayList<Button>();
+	private Button selectAllButton, clearAllButton;
+	
+	public DiagnosticsDialog(Shell parentShell, CodewindConnection conn) {
+		super(parentShell);
+		this.conn = conn;
+	}
+	
+	@Override
+	protected void configureShell(Shell newShell) {
+		super.configureShell(newShell);
+		newShell.setText(Messages.DiagnosticsDialogShell);
+	}
+	
+	@Override
+	protected boolean isResizable() {
+		return true;
+	}
+	
+	protected Control createDialogArea(Composite parent) {
+		setTitleImage(CodewindUIPlugin.getImage(CodewindUIPlugin.CODEWIND_BANNER));
+		setTitle(NLS.bind(Messages.DiagnosticsDialogTitle, conn.getName()));
+		setMessage(Messages.DiagnosticsDialogMsg);
+		
+		final Composite composite = new Composite(parent, SWT.NONE);
+		GridLayout layout = new GridLayout();
+		layout.marginHeight = 11;
+		layout.marginWidth = 9;
+		layout.horizontalSpacing = 5;
+		layout.verticalSpacing = 15;
+		layout.numColumns = 2;
+		composite.setLayout(layout);
+		GridData data = new GridData(GridData.FILL_BOTH);
+		data.widthHint = 200;
+		composite.setLayoutData(data);
+		composite.setFont(parent.getFont());
+		
+		Text text = new Text(composite, SWT.WRAP | SWT.READ_ONLY);
+		text.setText(Messages.DiagnosticsDialogAdditionalInfoText);
+		text.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 2, 1));
+		IDEUtil.normalizeBackground(text, composite);
+		
+		Group group = new Group(composite, SWT.NONE);
+		group.setText(Messages.DiagnosticsDialogAdditionalInfoGroup);
+		layout = new GridLayout();
+		layout.marginHeight = 11;
+		layout.marginWidth = 9;
+		layout.horizontalSpacing = 5;
+		layout.verticalSpacing = 7;
+		group.setLayout(layout);
+		group.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+		
+		eclipseWorkspaceButton = new Button(group, SWT.CHECK);
+		eclipseWorkspaceButton.setText(Messages.DiagnosticsDialogEclipseWorkspaceButton);
+		includeButtons.add(eclipseWorkspaceButton);
+		
+		projectInfoButton = new Button(group, SWT.CHECK);
+		projectInfoButton.setText(Messages.DiagnosticsDialogProjectInfoButton);
+		includeButtons.add(projectInfoButton);
+		
+		Composite buttonComposite = new Composite(composite, SWT.NONE);
+		layout = new GridLayout();
+		layout.marginHeight = 11;
+		layout.marginWidth = 9;
+		layout.horizontalSpacing = 5;
+		layout.verticalSpacing = 7;
+		buttonComposite.setLayout(layout);
+		buttonComposite.setLayoutData(new GridData(SWT.FILL, SWT.END, false, false));
+		
+		selectAllButton = new Button(buttonComposite, SWT.PUSH);
+		selectAllButton.setText(Messages.DiagnosticsDialogSelectAllButton);
+		selectAllButton.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
+		
+		clearAllButton = new Button(buttonComposite, SWT.PUSH);
+		clearAllButton.setText(Messages.DiagnosticsDialogClearAllButton);
+		clearAllButton.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
+		
+		eclipseWorkspaceButton.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				updateSelectButtons();
+			}
+		});
+		
+		projectInfoButton.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				updateSelectButtons();
+			}
+		});
+		
+		selectAllButton.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				includeButtons.stream().forEach(button -> button.setSelection(true));
+				updateSelectButtons();
+			}
+		});
+		
+		clearAllButton.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				includeButtons.stream().forEach(button -> button.setSelection(false));
+				updateSelectButtons();
+			}
+		});
+		
+		// Add Context Sensitive Help
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(parent, CodewindUIPlugin.MAIN_CONTEXTID);
+		
+		eclipseWorkspaceButton.setSelection(true);
+		projectInfoButton.setSelection(false);
+		updateSelectButtons();
+		
+		return composite;
+	}
+	
+	private void updateSelectButtons() {
+		selectAllButton.setEnabled(includeButtons.stream().filter(button -> !button.getSelection()).findFirst().isPresent());
+		clearAllButton.setEnabled(includeButtons.stream().filter(button -> button.getSelection()).findFirst().isPresent());
+	}
+
+	@Override
+	protected void okPressed() {
+		includeEclipseWorkspace = eclipseWorkspaceButton.getSelection();
+		includeProjectInfo = projectInfoButton.getSelection();
+		super.okPressed();
+	}
+
+	@Override
+	protected Point getInitialSize() {
+		Point point = super.getInitialSize();
+		return new Point(750, point.y);
+	}
+	
+	public boolean includeEclipseWorkspace() {
+		return includeEclipseWorkspace;
+	}
+	
+	public boolean includeProjectInfo() {
+		return includeProjectInfo;
+	}
+}


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
Adds an action to collect Codewind diagnostics. This action is only available if support features are enabled in the preferences. When the action is invoked a dialog pops up to allow the user to choose what to include in the diagnostics. A launch is created for generating the diagnostics and the console view is opened so the user can see the output.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2851

## Does this PR require a documentation change ?
Yes

## Any special notes for your reviewer ?
No