### PR TITLE
CW Issue #2813: Fix debug connect timeout and debug error handling

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
@@ -64,7 +64,7 @@ public class CodewindEclipseApplication extends CodewindApplication {
 	public static final String QUICK_FIX_DESCRIPTION = "quickFixDescription";
 	
 	// in seconds
-	public static final int DEFAULT_DEBUG_CONNECT_TIMEOUT = 3;
+	public static final int DEFAULT_DEBUG_CONNECT_TIMEOUT = 10;
 	
 	// New consoles
 	private Set<SocketConsole> activeConsoles = new HashSet<SocketConsole>();

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/launch/CodewindDebugConnector.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/launch/CodewindDebugConnector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -48,23 +48,23 @@ public class CodewindDebugConnector {
 		String host = config.getAttribute(CodewindLaunchConfigDelegate.HOST_ATTR, (String)null);
 		int debugPort = config.getAttribute(CodewindLaunchConfigDelegate.DEBUG_PORT_ATTR, -1);
 		if (projectName == null || host == null || debugPort <= 0) {
-        	String msg = "The launch configuration did not contain the required attributes: " + config.getName();		// $NON-NLS-1$
+        	String msg = "The launch configuration did not contain the required attributes: " + config.getName(); // $NON-NLS-1$
             Logger.logError(msg);
-            return null;
+            throw new CoreException(new Status(IStatus.ERROR, CodewindCorePlugin.PLUGIN_ID, msg));
         }
 		
-    	Logger.log("Debugging on port " + debugPort); //$NON-NLS-1$
+		Logger.log("Debugging on port " + debugPort); //$NON-NLS-1$
 
 		int timeout = CodewindCorePlugin.getDefault().getPreferenceStore()
-				.getInt(CodewindCorePlugin.DEBUG_CONNECT_TIMEOUT_PREFSKEY)
-				* 1000;
-		Logger.log("Debugger connect timeout is " + timeout + "ms"); //$NON-NLS-1$ //$NON-NLS-2$
+				.getInt(CodewindCorePlugin.DEBUG_CONNECT_TIMEOUT_PREFSKEY);
+		Logger.log("Debugger connect timeout is " + timeout + "s"); //$NON-NLS-1$ //$NON-NLS-2$
 
 		// Now prepare the Debug Connector, and try to attach it to the application
 		AttachingConnector connector = LaunchUtilities.getAttachingConnector();
 		if (connector == null) {
-			Logger.logError("Could not create debug connector"); //$NON-NLS-1$
-			return null;
+			String msg = "Could not create debug connector for launch configuration: " + config.getName(); //$NON-NLS-1$
+			Logger.logError(msg);
+			throw new CoreException(new Status(IStatus.ERROR, CodewindCorePlugin.PLUGIN_ID, msg));
 		}
 
 		Map<String, Connector.Argument> connectorArgs = connector.defaultArguments();

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/launch/UtilityLaunchConfigDelegate.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/launch/UtilityLaunchConfigDelegate.java
@@ -23,14 +23,15 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.model.IProcess;
+import org.eclipse.debug.core.model.LaunchConfigurationDelegate;
 import org.eclipse.debug.core.model.RuntimeProcess;
-import org.eclipse.jdt.launching.AbstractJavaLaunchConfigurationDelegate;
 import org.eclipse.osgi.util.NLS;
 
-public class UtilityLaunchConfigDelegate extends AbstractJavaLaunchConfigurationDelegate {
+public class UtilityLaunchConfigDelegate extends LaunchConfigurationDelegate {
 
 	public static final String LAUNCH_CONFIG_ID = "org.eclipse.codewind.core.internal.utilityLaunchConfigurationType";
 
@@ -62,7 +63,7 @@ public class UtilityLaunchConfigDelegate extends AbstractJavaLaunchConfiguration
 			launch.addProcess(process);
 		} catch (Exception e) {
 			monitor.setCanceled(true);
-			getLaunchManager().removeLaunch(launch);
+			DebugPlugin.getDefault().getLaunchManager().removeLaunch(launch);
 			if (e instanceof CoreException) {
 				throw (CoreException) e;
 			}


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
- Fixes the code to not multiply the debug attach timeout by 1000
- Increases the default timeout so users don't suddenly get timeouts when they didn't before
- Some exceptions were being ignored so changed the code to pass the exception on
- Fixes the UtilityLaunchConfigDelegate to extend LaunchConfigurationDelegate  instead of the Java launch delegate


## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2813

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No