### PR TITLE
CW Issue #2885: Fix the remote debug relaunch

### DIFF
--- a/dev/org.eclipse.codewind.core/plugin.properties
+++ b/dev/org.eclipse.codewind.core/plugin.properties
@@ -16,6 +16,7 @@ Bundle-Vendor = Eclipse.org
 Bundle-Name = Codewind Core Plug-in
 
 LAUNCH_CONFIG_NAME=Codewind Project
+REMOTE_LAUNCH_CONFIG_NAME=Remote Codewind Project
 UTILITY_LAUNCH_CONFIG_NAME=Codewind Utility
 
 VALIDATION_MARKER=Codewind Problem

--- a/dev/org.eclipse.codewind.core/plugin.xml
+++ b/dev/org.eclipse.codewind.core/plugin.xml
@@ -24,6 +24,14 @@
       sourceLocatorId="org.eclipse.jdt.launching.sourceLocator.JavaSourceLookupDirector"
       sourcePathComputerId="org.eclipse.codewind.core.internal.CodewindSourcePathComputer"/>
     <launchConfigurationType
+      id="org.eclipse.codewind.core.internal.remoteLaunchConfigurationType"
+      name="%REMOTE_LAUNCH_CONFIG_NAME"
+      delegate="org.eclipse.codewind.core.internal.launch.RemoteLaunchConfigDelegate"
+      modes="run, debug"
+      public="false"
+      sourceLocatorId="org.eclipse.jdt.launching.sourceLocator.JavaSourceLookupDirector"
+      sourcePathComputerId="org.eclipse.codewind.core.internal.CodewindSourcePathComputer"/>
+    <launchConfigurationType
       id="org.eclipse.codewind.core.internal.utilityLaunchConfigurationType"
       name="%UTILITY_LAUNCH_CONFIG_NAME"
       delegate="org.eclipse.codewind.core.internal.launch.UtilityLaunchConfigDelegate"

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
@@ -141,7 +141,7 @@ public class CodewindEclipseApplication extends CodewindApplication {
 				try {
 					if (app.projectLanguage.isJava()) {
 						ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
-				        ILaunchConfigurationType launchConfigurationType = launchManager.getLaunchConfigurationType(CodewindLaunchConfigDelegate.LAUNCH_CONFIG_ID);
+				        ILaunchConfigurationType launchConfigurationType = launchManager.getLaunchConfigurationType(getLaunchConfigId());
 				        ILaunchConfigurationWorkingCopy workingCopy = launchConfigurationType.newInstance((IContainer) null, app.name);
 				        CodewindLaunchConfigDelegate.setConfigAttributes(workingCopy, app);
 				        ILaunchConfiguration launchConfig = workingCopy.doSave();
@@ -164,6 +164,10 @@ public class CodewindEclipseApplication extends CodewindApplication {
 		};
 		job.setPriority(Job.LONG);
 		job.schedule();
+	}
+	
+	public String getLaunchConfigId() {
+		return CodewindLaunchConfigDelegate.LAUNCH_CONFIG_ID;
 	}
 
 	@Override

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/KubeUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/KubeUtil.java
@@ -20,6 +20,7 @@ import org.eclipse.codewind.core.internal.launch.UtilityLaunchConfigDelegate;
 import org.eclipse.codewind.core.internal.messages.Messages;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -50,37 +51,32 @@ public class KubeUtil {
 		return kubeCommand;
 	}
 	
-	public static PortForwardInfo startPortForward(CodewindApplication app, int port) throws Exception {
-		// Check the app
-		if (app.getPodName() == null || app.getNamespace() == null) {
-			// This should not happen
-			Logger.logError("Trying to port forward for the " + app.name + " project but the pod name or the namespace is null");
-			return null;
-		}
+	/**
+	 * Starts a port forward process which can be added to an existing launch
+	 */
+	public static PortForwardInfo startPortForward(CodewindApplication app, int localPort, int port) throws Exception {
+		// Check the app (throws an exception if there is a problem)
+		checkApp(app);
+		
+		// Get the command
+		List<String> commandList = getPortForwardCommand(app, localPort, port);
+		
+		// Create the process
+		ProcessBuilder builder = new ProcessBuilder(commandList);
+		Process process = builder.start();
+		return new PortForwardInfo(localPort, port, process);
+	}
+	
+	/**
+	 * Starts a separate port forward launch
+	 */
+	public static PortForwardInfo launchPortForward(CodewindApplication app, int localPort, int port) throws Exception {
+		// Check the app (throws an exception if there is a problem)
+		checkApp(app);
 
 		// Get the command
-		String processPath = KubeUtil.getCommand();
-		if (processPath == null) {
-			Logger.logError("Port forwarding cannot be initiated because neither of the kubectl or oc commands could be found on the path");
-			throw new IOException(Messages.ErrorNoKubectlMsg);
-		}
-
-		// Find a free port
-		int localPort = PlatformUtil.findFreePort();
-		if (localPort == -1) {
-			Logger.logError("Could not find a free port to use for port forwarding for project: " + app.name);
-			return null;
-		}
-
-		String portMapping = localPort + ":" + port; //$NON-NLS-1$
-		List<String> commandList = new ArrayList<String>();
-		commandList.add(processPath);
-		commandList.add("port-forward");
-		commandList.add("-n");
-		commandList.add(app.getNamespace());
-		commandList.add(app.getPodName());
-		commandList.add(portMapping);
-		String title = NLS.bind(Messages.PortForwardTitle, portMapping);
+		List<String> commandList = getPortForwardCommand(app, localPort, port);
+		String title = NLS.bind(Messages.PortForwardTitle, localPort + ":" + port);
 
 		ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
 		ILaunchConfigurationType launchConfigurationType = launchManager.getLaunchConfigurationType(UtilityLaunchConfigDelegate.LAUNCH_CONFIG_ID);
@@ -92,28 +88,77 @@ public class KubeUtil {
 		CodewindLaunchConfigDelegate.setConfigAttributes(workingCopy, app);
 		ILaunchConfiguration launchConfig = workingCopy.doSave();
 		ILaunch launch = launchConfig.launch(ILaunchManager.RUN_MODE, new NullProgressMonitor());
-
 		return new PortForwardInfo(localPort, port, launch);
 	}
 	
-	public static void endPortForward(CodewindApplication app, PortForwardInfo pfInfo) throws Exception {
-		if (pfInfo != null && pfInfo.launch != null) {
-			if (!pfInfo.launch.isTerminated()) {
-				pfInfo.launch.terminate();
-			}
+	private static void checkApp(CodewindApplication app) throws IOException {
+		// Check the app
+		if (app.getPodName() == null || app.getNamespace() == null) {
+			// This should not happen
+			String msg = "Trying to run kubectl command for the " + app.name + " project but the pod name or the namespace is null";  // $NON-NLS-1$  // $NON-NLS-2$
+			Logger.logError(msg);
+			throw new IOException(msg);
 		}
+	}
+	
+	private static List<String> getPortForwardCommand(CodewindApplication app, int localPort, int port) throws Exception {
+		// Get the command
+		String processPath = KubeUtil.getCommand();
+		if (processPath == null) {
+			Logger.logError("Port forwarding cannot be initiated because neither of the kubectl or oc commands could be found on the path");
+			throw new IOException(Messages.ErrorNoKubectlMsg);
+		}
+
+		String portMapping = localPort + ":" + port; //$NON-NLS-1$
+		List<String> commandList = new ArrayList<String>();
+		commandList.add(processPath);
+		commandList.add("port-forward");
+		commandList.add("-n");
+		commandList.add(app.getNamespace());
+		commandList.add(app.getPodName());
+		commandList.add(portMapping);
+		return commandList;
 	}
 	
 	public static class PortForwardInfo {
 		public final int localPort;
 		public final int remotePort;
+		public final Process process;
 		public final ILaunch launch;
 		
+		public PortForwardInfo(int localPort, int remotePort, Process process) {
+			this(localPort, remotePort, process, null);
+		}
+		
 		public PortForwardInfo(int localPort, int remotePort, ILaunch launch) {
+			this(localPort, remotePort, null, launch);
+		}
+		
+		public void terminate() {
+			if (process != null && process.isAlive()) {
+				process.destroy();
+			}
+			if (launch != null && !launch.isTerminated()) {
+				try {
+					launch.terminate();
+				} catch (DebugException e) {
+					Logger.logError("An error occured trying to terminate the port forward launch: " + localPort + ":" + remotePort, e);
+				}
+			}
+		}
+		
+		public void terminateAndRemove() {
+			terminate();
+			if (launch != null) {
+				DebugPlugin.getDefault().getLaunchManager().removeLaunch(launch);
+			}
+		}
+		
+		private PortForwardInfo(int localPort, int remotePort, Process process, ILaunch launch) {
 			this.localPort = localPort;
 			this.remotePort = remotePort;
+			this.process = process;
 			this.launch = launch;
 		}
 	}
-
 }

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/launch/RemoteLaunchConfigDelegate.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/launch/RemoteLaunchConfigDelegate.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.codewind.core.internal.launch;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.codewind.core.internal.KubeUtil;
+import org.eclipse.codewind.core.internal.KubeUtil.PortForwardInfo;
+import org.eclipse.codewind.core.internal.Logger;
+import org.eclipse.codewind.core.internal.PlatformUtil;
+import org.eclipse.codewind.core.internal.RemoteEclipseApplication;
+import org.eclipse.codewind.core.internal.messages.Messages;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.debug.core.DebugEvent;
+import org.eclipse.debug.core.DebugException;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.IDebugEventSetListener;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.model.IDebugTarget;
+import org.eclipse.debug.core.model.IProcess;
+import org.eclipse.debug.core.model.RuntimeProcess;
+import org.eclipse.osgi.util.NLS;
+
+public class RemoteLaunchConfigDelegate extends CodewindLaunchConfigDelegate {
+	
+	public static final String LAUNCH_CONFIG_ID = "org.eclipse.codewind.core.internal.remoteLaunchConfigurationType";
+
+	@Override
+	public void launch(ILaunchConfiguration config, String launchMode, ILaunch launch, IProgressMonitor monitor)
+			throws CoreException {
+
+		try {
+			launchInner(config, launchMode, launch, monitor);
+		} catch (Exception e) {
+			String msg = "An error occurred trying to connect the debugger for launch configuration: " + config.getName(); // $NON-NLS-1$
+			Logger.logError(msg, e);
+			monitor.setCanceled(true);
+			getLaunchManager().removeLaunch(launch);
+			if (e instanceof CoreException) {
+				throw (CoreException) e;
+			}
+			abort(msg, e, IStatus.ERROR);
+		}
+	}
+
+	private void launchInner(ILaunchConfiguration config, String launchMode, ILaunch launch, IProgressMonitor monitor)
+			throws Exception {
+
+		RemoteEclipseApplication app = (RemoteEclipseApplication) getApp(config);
+
+		if (app.getContainerDebugPort() <= 0) {
+			String msg = "The container debug port is not set up for application: " + app.name; // $NON-NLS-1$
+			Logger.logError(msg);
+			abort(msg, null, IStatus.ERROR);
+		}
+
+		// Find a free port
+		int localPort = PlatformUtil.findFreePort();
+		if (localPort <= 0) {
+			String msg = "Could not find a free port for port forwarding the debug port for launch config: " + config.getName(); // $NON-NLS-1$
+			Logger.logError(msg);
+			abort(msg, null, IStatus.ERROR);
+		}
+
+		// Start the port forward
+		PortForwardInfo pfInfo = KubeUtil.startPortForward(app, localPort, app.getContainerDebugPort());
+		app.setDebugPFInfo(pfInfo);
+		Map<String, String> attributes = new HashMap<String, String>();
+		attributes.put(IProcess.ATTR_PROCESS_TYPE, "codewind.utility");
+		String title = NLS.bind(Messages.PortForwardTitle, localPort + ":" + app.getContainerDebugPort());
+		launch.addProcess(new RuntimeProcess(launch, pfInfo.process, title, attributes));
+
+		// Add the debug listener
+		DebugPlugin.getDefault().addDebugEventListener(new IDebugEventSetListener() {
+			@Override
+			public void handleDebugEvents(DebugEvent[] events) {
+				for (DebugEvent event : events) {
+					if (event.getKind() == DebugEvent.TERMINATE && event.getSource() instanceof IDebugTarget
+							&& ((IDebugTarget) event.getSource()).getLaunch() == launch) {
+						// Remove this listener
+						DebugPlugin.getDefault().removeDebugEventListener(this);
+
+						// Make sure the port forward is terminated
+						Arrays.stream(launch.getProcesses()).filter(process -> !process.isTerminated()).forEach(process -> {
+							try {
+								process.terminate();
+							} catch (DebugException e) {
+								Logger.logError("An error occurred trying to terminate the process: " + process.getLabel(), e);
+							}
+						});
+
+						// No need to process the rest of the events
+						break;
+					}
+				}
+			}
+		});
+
+		// Launch the debug session
+		super.launch(config, launchMode, launch, monitor);
+	}
+}

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
@@ -111,7 +111,7 @@ ErrorNoKubectlMsg=Neither of the kubectl or oc commands could be found on the pa
 UtilityLaunchError=An error occurred trying to launch: {0}
 UtilGenDiagnosticsTitle=Collect diagnostics
 
-PortForwardTitle=Port forward {0}
+PortForwardTitle=Debug port forward {0}
 PortForwardTerminateTitle=Port Forwarding Terminated
 PortForwardTerminateMsg=Port forwarding has terminated for application {0} ({1}) and port {2}. Anything that was depending on this such as a debug session will also terminate.
 PortForwardTerminateToggleMsg=Don't show this message again

--- a/dev/org.eclipse.codewind.ui/plugin.xml
+++ b/dev/org.eclipse.codewind.ui/plugin.xml
@@ -45,6 +45,14 @@
 			id="org.eclipse.codewind.core.internal.launchConfigurationTypeImage"
 			configTypeID="org.eclipse.codewind.core.internal.launchConfigurationType"
 			icon="%DEFAULT_ICON_PATH"/>
+		<launchConfigurationTypeImage
+			id="org.eclipse.codewind.core.internal.remoteLaunchConfigurationTypeImage"
+			configTypeID="org.eclipse.codewind.core.internal.remoteLaunchConfigurationType"
+			icon="%DEFAULT_ICON_PATH"/>
+		<launchConfigurationTypeImage
+			id="org.eclipse.codewind.core.internal.utilityLaunchConfigurationTypeImage"
+			configTypeID="org.eclipse.codewind.core.internal.utilityLaunchConfigurationType"
+			icon="%DEFAULT_ICON_PATH"/>
 	</extension>
 	
 	<extension point="org.eclipse.debug.ui.launchConfigurationTabGroups">

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -348,6 +348,7 @@ public class Messages extends NLS {
 	public static String NodeJSOpenBrowserTitle;
 	public static String NodeJSOpenBrowserDesc;
 	public static String NodeJSOpenBrowserJob;
+	public static String NodeJSDebugPortForwardError;
 	public static String NodeJSDebugURLError;
 	
 	public static String BrowserSelectionTitle;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -342,6 +342,7 @@ NodeJsBrowserDialogPasteMessage=Open the browser, and paste the following into y
 NodeJSOpenBrowserTitle=Node.js Debug Inspector URL
 NodeJSOpenBrowserDesc=To access the Node.js debug inspector, a custom DevTools URL must be entered in the address bar of a Chromium based browser.
 NodeJSOpenBrowserJob=Opening browser for Node.js debugging.
+NodeJSDebugPortForwardError=An error occurred trying to forward the debug port for the {0} application.
 NodeJSDebugURLError=Failed to get the debug URL for the {0} application.
 
 BrowserSelectionTitle=Launch the Node.js Debugger


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Fixes the remote debug relaunch problem by including the port forward setup in the launch.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2885

## Does this PR require a documentation change ?
Yes - there is no longer a separate port forward launch in the Java case. Instead it is a second process in the debug launch. For Node.js projects there is still a port forward launch.

## Any special notes for your reviewer ?
No