### PR TITLE
CW Issue #2917: Check if the overview page is disposed before updating

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
@@ -285,6 +285,9 @@ public class ApplicationOverviewEditorPart extends EditorPart implements UpdateL
 	}
 	
 	public void update(CodewindConnection conn, CodewindApplication app, boolean init) {
+		if (form.isDisposed()) {
+			return;
+		}
 		boolean changed = false;
 		if (conn == null || !conn.isConnected() || app == null) {
 			changed = !messageComp.getVisible();


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Makes sure that the application overview page is not disposed before trying to update it.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2917

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No