### PR TITLE
CW Issue #2924: Project deployed dialog usability improvements

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -194,6 +194,7 @@ public class Messages extends NLS {
 	public static String ProjectDeployedDialogShell;
 	public static String ProjectDeployedDialogTitle;
 	public static String ProjectDeployedDialogMessage;
+	public static String ProjectDeployedDialogInstructions;
 	public static String ProjectDeployedDialogGroupLabel;
 	public static String ProjectDeployedDialogRemoveLabel;
 	public static String ProjectDeployedDialogRemoveTooltip;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -150,14 +150,15 @@ MoveProjectTimeout=A timeout occurred while moving the {0} project from {1} to {
 
 ProjectDeployedDialogShell=Manage Deployments
 ProjectDeployedDialogTitle=Project Already Deployed
-ProjectDeployedDialogMessage=The project at location {0} is already deployed and enabled on other connections. It is not recommended to have the same project on multiple connections.
-ProjectDeployedDialogGroupLabel=Choose the behaviour for existing enabled deployments
+ProjectDeployedDialogMessage=The project at location {0} is already deployed and enabled on other connections.
+ProjectDeployedDialogInstructions=The project is already deployed on these connections: {0}. Remove, disable, or maintain the existing deployments of this project. Click Cancel to go back and select a different project.
+ProjectDeployedDialogGroupLabel=Choose the behavior for existing enabled deployments
 ProjectDeployedDialogRemoveLabel=Remove
-ProjectDeployedDialogRemoveTooltip=Remove any existing enabled deployments
+ProjectDeployedDialogRemoveTooltip=Remove existing enabled deployments before adding the project to the {0} connection.
 ProjectDeployedDialogDisableLabel=Disable
-ProjectDeployedDialogDisableTooltip=Disable any existing enabled deployments
+ProjectDeployedDialogDisableTooltip=Disable existing enabled deployments before adding the project to the {0} connection.
 ProjectDeployedDialogMaintainLabel=Maintain
-ProjectDeployedDialogMaintainTooltip=Do not make any changes to existing enabled deployments
+ProjectDeployedDialogMaintainTooltip=Do not make any changes to existing enabled deployments before adding the project to the {0} connection.
 
 InstallCodewindJobLabel=Installing Codewind
 StartingCodewindJobLabel=Starting Codewind

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/BindProjectWizard.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/BindProjectWizard.java
@@ -198,7 +198,7 @@ public class BindProjectWizard extends Wizard implements INewWizard {
 		// If the application is deployed on another connection, ask the user what they want to do
 		final ProjectDeployedDialog.Behaviour selectedBehaviour;
 		if (!existingDeployments.isEmpty()) {
-			ProjectDeployedDialog dialog = new ProjectDeployedDialog(getShell(), projectPath);
+			ProjectDeployedDialog dialog = new ProjectDeployedDialog(getShell(), projectPath, connection, existingDeployments);
 			if (dialog.open() == IStatus.OK) {
 				selectedBehaviour = dialog.getSelectedBehaviour();
 			} else {

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectDeployedDialog.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/ProjectDeployedDialog.java
@@ -11,7 +11,14 @@
 
 package org.eclipse.codewind.ui.internal.wizards;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.codewind.core.internal.CodewindApplication;
+import org.eclipse.codewind.core.internal.CoreUtil;
+import org.eclipse.codewind.core.internal.connection.CodewindConnection;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
+import org.eclipse.codewind.ui.internal.IDEUtil;
 import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.dialogs.TitleAreaDialog;
@@ -27,6 +34,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.PlatformUI;
 
 public class ProjectDeployedDialog extends TitleAreaDialog {
@@ -38,11 +46,15 @@ public class ProjectDeployedDialog extends TitleAreaDialog {
 	};
 	
 	private final IPath projectPath;
+	private final CodewindConnection newConn;
+	private final List<CodewindApplication> existingDeployments;
 	private Behaviour selectedBehaviour = Behaviour.REMOVE;
 	
-	public ProjectDeployedDialog(Shell parentShell, IPath projectPath) {
+	public ProjectDeployedDialog(Shell parentShell, IPath projectPath, CodewindConnection newConn, List<CodewindApplication> existingDeployments) {
 		super(parentShell);
 		this.projectPath = projectPath;
+		this.newConn = newConn;
+		this.existingDeployments = existingDeployments;
 	}
 	
 	@Override
@@ -66,12 +78,17 @@ public class ProjectDeployedDialog extends TitleAreaDialog {
 		layout.marginHeight = 11;
 		layout.marginWidth = 9;
 		layout.horizontalSpacing = 5;
-		layout.verticalSpacing = 7;
+		layout.verticalSpacing = 15;
 		composite.setLayout(layout);
 		GridData data = new GridData(GridData.FILL_BOTH);
 		data.widthHint = 200;
 		composite.setLayoutData(data);
 		composite.setFont(parent.getFont());
+		
+		Text instructionText = new Text(composite, SWT.READ_ONLY | SWT.MULTI | SWT.WRAP);
+		instructionText.setText(NLS.bind(Messages.ProjectDeployedDialogInstructions, getExistingConnections()));
+		IDEUtil.normalizeBackground(instructionText, composite);
+		instructionText.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 		
 		Group radioGroup = new Group(composite, SWT.NONE);
 		layout = new GridLayout();
@@ -83,9 +100,9 @@ public class ProjectDeployedDialog extends TitleAreaDialog {
 		radioGroup.setText(Messages.ProjectDeployedDialogGroupLabel);
 		radioGroup.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 		
-		Button removeButton = addBehaviourButton(radioGroup, Messages.ProjectDeployedDialogRemoveLabel, Messages.ProjectDeployedDialogRemoveTooltip, Behaviour.REMOVE);
-		addBehaviourButton(radioGroup, Messages.ProjectDeployedDialogDisableLabel, Messages.ProjectDeployedDialogDisableTooltip, Behaviour.DISABLE);
-		addBehaviourButton(radioGroup, Messages.ProjectDeployedDialogMaintainLabel, Messages.ProjectDeployedDialogMaintainTooltip, Behaviour.MAINTAIN);
+		Button removeButton = addBehaviourButton(radioGroup, Messages.ProjectDeployedDialogRemoveLabel, NLS.bind(Messages.ProjectDeployedDialogRemoveTooltip, newConn.getName()), Behaviour.REMOVE);
+		addBehaviourButton(radioGroup, Messages.ProjectDeployedDialogDisableLabel, NLS.bind(Messages.ProjectDeployedDialogDisableTooltip, newConn.getName()), Behaviour.DISABLE);
+		addBehaviourButton(radioGroup, Messages.ProjectDeployedDialogMaintainLabel, NLS.bind(Messages.ProjectDeployedDialogMaintainTooltip, newConn.getName()), Behaviour.MAINTAIN);
 
 		// Add Context Sensitive Help
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(parent, CodewindUIPlugin.MAIN_CONTEXTID);
@@ -121,5 +138,16 @@ public class ProjectDeployedDialog extends TitleAreaDialog {
 	protected Point getInitialSize() {
 		Point point = super.getInitialSize();
 		return new Point(750, point.y);
+	}
+	
+	private String getExistingConnections() {
+		List<String> connectionNames = new ArrayList<String>();
+		existingDeployments.forEach(app -> {
+			if (!connectionNames.contains(app.connection.getName())) {
+				connectionNames.add(app.connection.getName());
+			}
+		});
+		connectionNames.sort((String str1, String str2) -> str1.compareTo(str2));
+		return CoreUtil.formatString(connectionNames.toArray(new String[connectionNames.size()]), ", ");
 	}
 }


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Improve the usability of the project deployed dialog.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2924

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
I could use a table with a Connection column and an Action column. The Connection column would show the names of connections where the project is already deployed. The Action column would show which action to take for each connection (Remove, Disable, Maintain). There would be buttons for users to change the action on the selected connections (outside the table since buttons or dropdowns in a table are not accessible). I think this would be overkill though since most users won't even see this dialog and those that do will only have the project deployed on one other connection.