### PR TITLE
CW Issue #655: Use tooltip to provide detailed status to user

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindApplication.java
@@ -25,6 +25,7 @@ import org.eclipse.codewind.core.internal.console.ProjectLogInfo;
 import org.eclipse.codewind.core.internal.constants.AppStatus;
 import org.eclipse.codewind.core.internal.constants.BuildStatus;
 import org.eclipse.codewind.core.internal.constants.CoreConstants;
+import org.eclipse.codewind.core.internal.constants.DetailedAppStatus;
 import org.eclipse.codewind.core.internal.constants.ProjectCapabilities;
 import org.eclipse.codewind.core.internal.constants.ProjectLanguage;
 import org.eclipse.codewind.core.internal.constants.ProjectType;
@@ -48,7 +49,7 @@ public class CodewindApplication {
 	private String contextRoot;	// can be null
 	private StartMode startMode;
 	private AppStatus appStatus;
-	private String appStatusDetails;
+	private DetailedAppStatus appStatusDetails;
 	private BuildStatus buildStatus;
 	private String buildDetails;
 	private boolean autoBuild = true;
@@ -123,14 +124,10 @@ public class CodewindApplication {
 		}
 	}
 
-	public synchronized void setAppStatus(String appStatus, String appStatusDetails) {
+	public synchronized void setAppStatus(String appStatus, DetailedAppStatus appStatusDetails) {
 		if (appStatus != null) {
 			this.appStatus = AppStatus.get(appStatus);
-			if (appStatusDetails == null || appStatusDetails.trim().isEmpty()) {
-				this.appStatusDetails = null;
-			} else {
-				this.appStatusDetails = appStatusDetails;
-			}
+			this.appStatusDetails = appStatusDetails;
 		}
 	}
 	
@@ -139,7 +136,7 @@ public class CodewindApplication {
 			BuildStatus newStatus = BuildStatus.get(buildStatus);
 			boolean hasChanged = newStatus != this.buildStatus;
 			this.buildStatus = newStatus;
-			if (buildDetails != null && buildDetails.trim().isEmpty()) {
+			if (buildDetails == null || buildDetails.trim().isEmpty()) {
 				this.buildDetails = null;
 			} else {
 				this.buildDetails = buildDetails;
@@ -328,7 +325,7 @@ public class CodewindApplication {
 		return appStatus;
 	}
 	
-	public synchronized String getAppStatusDetails() {
+	public synchronized DetailedAppStatus getAppStatusDetails() {
 		return appStatusDetails;
 	}
 	

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/RemoteEclipseApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/RemoteEclipseApplication.java
@@ -17,6 +17,7 @@ import org.eclipse.codewind.core.CodewindCorePlugin;
 import org.eclipse.codewind.core.internal.KubeUtil.PortForwardInfo;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
 import org.eclipse.codewind.core.internal.constants.AppStatus;
+import org.eclipse.codewind.core.internal.constants.DetailedAppStatus;
 import org.eclipse.codewind.core.internal.constants.ProjectLanguage;
 import org.eclipse.codewind.core.internal.constants.ProjectType;
 import org.eclipse.codewind.core.internal.constants.StartMode;
@@ -102,7 +103,7 @@ public class RemoteEclipseApplication extends CodewindEclipseApplication {
 	}
 
 	@Override
-	public synchronized void setAppStatus(String appStatus, String appStatusDetails) {
+	public synchronized void setAppStatus(String appStatus, DetailedAppStatus appStatusDetails) {
 		if (appStatus != null) {
 			AppStatus oldStatus = getAppStatus();
 			super.setAppStatus(appStatus, appStatusDetails);

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/DetailedAppStatus.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/constants/DetailedAppStatus.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.codewind.core.internal.constants;
+
+import org.eclipse.codewind.core.internal.Logger;
+import org.eclipse.codewind.core.internal.connection.JSONObjectResult;
+import org.eclipse.codewind.core.internal.messages.Messages;
+import org.json.JSONObject;
+
+public class DetailedAppStatus extends JSONObjectResult {
+	
+	private static final String SEVERITY_KEY = "severity";
+	private static final String MESSAGE_KEY = "message";
+	private static final String NOTIFY_KEY = "notify";
+	private static final String NOTIFICATION_ID_KEY = "notificationID";
+	
+	public enum Severity {
+		ERROR("ERROR", Messages.SeverityError),
+		WARNING("WARN", Messages.SeverityWarning),
+		INFO("INFO", Messages.SeverityInfo);
+
+		public final String level;
+		public final String displayString;
+
+		private Severity(String level, String displayString) {
+			this.level = level;
+			this.displayString = displayString;
+		}
+		
+		public static Severity get(String severity) {
+			for (Severity sev : Severity.values()) {
+				if (sev.level.equals(severity)) {
+					return sev;
+				}
+			}
+			Logger.logError("Unrecognized severity: " + severity);
+			return null;
+		}
+
+		public String getDisplayString(StartMode mode) {
+			return displayString;
+		}
+	};
+	
+	public DetailedAppStatus(JSONObject connectionInfo) {
+		super(connectionInfo, "detailed app status");
+	}
+	
+	public Severity getSeverity() {
+		String severity = getString(SEVERITY_KEY);
+		if (severity != null) {
+			return Severity.get(severity);
+		}
+		return null;
+	}
+	
+	public String getMessage() {
+		String msg = getString(MESSAGE_KEY);
+		return msg == null || msg.isEmpty() ? null : msg;
+	}
+	
+	public boolean getNotify() {
+		return getBoolean(NOTIFY_KEY);
+	}
+
+	public String getNotificationID() {
+		String id = getString(NOTIFICATION_ID_KEY);
+		return id == null || id.isEmpty() ? null : id;
+	}
+}

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
@@ -69,6 +69,10 @@ public class Messages extends NLS {
 	public static String AppStatusUnknown;
 	public static String AppStatusDebugging;
 	
+	public static String SeverityError;
+	public static String SeverityWarning;
+	public static String SeverityInfo;
+	
 	public static String BuildStateQueued;
 	public static String BuildStateInProgress;
 	public static String BuildStateSuccess;

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
@@ -62,6 +62,10 @@ AppStatusStopped=Stopped
 AppStatusUnknown=No status information
 AppStatusDebugging=Debugging
 
+SeverityError=Error
+SeverityWarning=Warning
+SeverityInfo=Info
+
 BuildStateQueued=Build queued
 BuildStateInProgress=Building
 BuildStateSuccess=Build successful

--- a/dev/org.eclipse.codewind.ui/plugin.xml
+++ b/dev/org.eclipse.codewind.ui/plugin.xml
@@ -86,6 +86,14 @@
 					pattern="org.eclipse.codewind.ui.navigatorContent"/>
 			</includes>
 		</viewerContentBinding>
+		<viewer
+			viewerId="org.eclipse.codewind.ui.explorerView">
+			<options>
+				<property
+					name="org.eclipse.ui.navigator.enableTooltipSupport"
+					value="true" />
+			</options>
+		</viewer>
 	</extension>
 
 	<extension point="org.eclipse.ui.navigator.navigatorContent">

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
@@ -19,6 +19,7 @@ import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
 import org.eclipse.codewind.core.internal.connection.CodewindConnectionManager;
 import org.eclipse.codewind.core.internal.connection.LocalConnection;
+import org.eclipse.codewind.core.internal.constants.DetailedAppStatus;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
 import org.eclipse.codewind.ui.internal.IDEUtil;
 import org.eclipse.codewind.ui.internal.UIConstants;
@@ -399,8 +400,8 @@ public class ApplicationOverviewEditorPart extends EditorPart implements UpdateL
 		public void update(CodewindApplication app) {
 			autoBuildEntry.setValue(app.isAutoBuild() ? Messages.AppOverviewEditorAutoBuildOn : Messages.AppOverviewEditorAutoBuildOff, true);
 			injectMetricsEntry.setValue(metricsInjectionState(app.canInjectMetrics(), app.isMetricsInjected()), true);
-			appStatusEntry.setValue(app.isAvailable() ? app.getAppStatus().getDisplayString(app.getStartMode()) : Messages.AppOverviewEditorStatusDisabled, true);
-			buildStatusEntry.setValue(app.isAvailable() ? app.getBuildStatus().getDisplayString() : null, true);
+			appStatusEntry.setValue(getAppStatusString(app), true);
+			buildStatusEntry.setValue(getBuildStatusString(app), true);
 			long lastImageBuild = app.getLastImageBuild();
 			String lastImageBuildStr = Messages.AppOverviewEditorImageNeverBuilt;
 			if (lastImageBuild > 0) {
@@ -413,6 +414,34 @@ public class ApplicationOverviewEditorPart extends EditorPart implements UpdateL
 				lastBuildStr = formatTimestamp(lastBuild);
 			}
 			lastBuildEntry.setValue(lastBuildStr, true);
+		}
+		
+		private String getAppStatusString(CodewindApplication app) {
+			if (app.isAvailable()) {
+				StringBuilder builder = new StringBuilder();
+				builder.append(app.getAppStatus().getDisplayString(app.getStartMode()));
+				DetailedAppStatus details = app.getAppStatusDetails();
+				if (details != null && details.getMessage() != null) {
+					builder.append(": ");
+					if (details.getSeverity() != null) {
+						builder.append("(" + details.getSeverity().displayString + ") ");
+					}
+					builder.append(details.getMessage());
+				}
+				return builder.toString();
+			}
+			return Messages.AppOverviewEditorStatusDisabled;
+		}
+		
+		private String getBuildStatusString(CodewindApplication app) {
+			if (app.isAvailable()) {
+				String buildStatusStr = app.getBuildStatus().getDisplayString();
+				if (app.getBuildDetails() != null) {
+					buildStatusStr += " (" + app.getBuildDetails() + ")";
+				}
+				return buildStatusStr;
+			}
+			return null;
 		}
 	}
 	

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -115,6 +115,7 @@ public class Messages extends NLS {
 	public static String CodewindProjectDisabled;
 	public static String CodewindConnectionNoProjects;
 	public static String CodewindDescriptionContextRoot;
+	public static String CodewindHoverForDetails;
 	
 	public static String InstallerActionInstallLabel;
 	public static String InstallerActionUninstallLabel;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -95,11 +95,12 @@ CodewindStartingQualifier=Starting
 CodewindStoppingQualifier=Stopping
 CodewindErrorQualifier=Error
 CodewindErrorMsg=Disconnected. Check that Codewind is running and then right click and select Refresh.
-CodewindErrorMsgWithDetails=Disconnected. Select to show details in status bar. Check that Codewind is running and then right click and select Refresh.
+CodewindErrorMsgWithDetails=Disconnected. Hover for details. Check that Codewind is running and then right click and select Refresh.
 CodewindNotInstalledMsg=Double click to download the Codewind images
 CodewindWrongVersionQualifier=Unsupported version: {0}
 CodewindWrongVersionMsg=Double click to update to version: {0}
 CodewindNotStartedMsg=Double click to start
+CodewindHoverForDetails=Hover for details
 
 CodewindConnectionLabel=Codewind Connection:
 CodewindConnected=Connected


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
- Provides detailed status to user through tooltip in the Codewind Explorer view
- Adds the detailed app status and build status to the Project Overview page

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/655

## Does this PR require a documentation change ?
Yes - The tooltip support in common viewers was added to Eclipse 4.12 (2019-06) so 4.11 (2019-03) is not supported anymore.

## Any special notes for your reviewer ?
No