### PR TITLE
CW Issue #2992: Add link to documentation on push registry dialogs

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CoreUtil.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CoreUtil.java
@@ -87,27 +87,31 @@ public class CoreUtil {
 				MessageDialog dialog = new MessageDialog(Display.getDefault().getActiveShell(), title, null, msg, type.getValue(), 0, IDialogConstants.OK_LABEL) {
 					@Override
 					protected Control createCustomArea(Composite parent) {
-						Link link = new Link(parent, SWT.WRAP);
-						link.setText("<a>" + linkLabel + "</a>"); //$NON-NLS-1$ //$NON-NLS-2$
-						link.addSelectionListener(new SelectionAdapter() {
-							@Override
-							public void widgetSelected(SelectionEvent event) {
-								try {
-									IWorkbenchBrowserSupport browserSupport = PlatformUI.getWorkbench().getBrowserSupport();
-									IWebBrowser browser = browserSupport.getExternalBrowser();
-									URL url = new URL(linkUrl);
-									browser.openURL(url);
-								} catch (Exception e) {
-									Logger.logError("An error occurred trying to open an external browser at: " + link, e); //$NON-NLS-1$
-								}
-							}
-						});
-						return link;
+						return addLinkToDialog(parent, linkLabel, linkUrl);
 					}
 				};
 				dialog.open();
 			}
 		});
+	}
+	
+	public static Control addLinkToDialog(Composite parent, String linkLabel, String linkUrl) {
+		Link link = new Link(parent, SWT.WRAP);
+		link.setText("<a>" + linkLabel + "</a>"); //$NON-NLS-1$ //$NON-NLS-2$
+		link.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent event) {
+				try {
+					IWorkbenchBrowserSupport browserSupport = PlatformUI.getWorkbench().getBrowserSupport();
+					IWebBrowser browser = browserSupport.getExternalBrowser();
+					URL url = new URL(linkUrl);
+					browser.openURL(url);
+				} catch (Exception e) {
+					Logger.logError("An error occurred trying to open an external browser at: " + link, e); //$NON-NLS-1$
+				}
+			}
+		});
+		return link;
 	}
 
 	public static boolean openConfirmDialog(String title, String msg) {
@@ -120,8 +124,7 @@ public class CoreUtil {
 		});
 		return result[0];
 	}
-
-
+	
 	public static String readAllFromStream(InputStream stream) {
 		Scanner s = new Scanner(stream);
 		// end-of-stream

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -417,6 +417,7 @@ public class Messages extends NLS {
 	public static String NoPushRegistryTitle;
 	public static String NoPushRegistryMessage;
 	public static String NoPushRegistryError;
+	public static String ImageRegistryDocLinkLabel;
 	
 	public static String AppOverviewEditorCreateError;
 	public static String AppOverviewEditorPartName;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -411,6 +411,7 @@ ManageRegistriesLinkTooltipLocal=Add any pull registries required by your projec
 NoPushRegistryTitle=Push Registry Required
 NoPushRegistryMessage=Codewind style projects require a push registry. Select OK to set one up or Cancel to cancel the current operation.
 NoPushRegistryError=The operation could not complete because no push registry was created.
+ImageRegistryDocLinkLabel=Learn more about image registries...
 
 AppOverviewEditorCreateError=The application overview editor could not be created for the input: {0}. Check the logs for more details.
 AppOverviewEditorPartName=Application Overview: {0} ({1})

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorDropAssistant.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorDropAssistant.java
@@ -15,11 +15,13 @@ import java.util.concurrent.TimeoutException;
 
 import org.eclipse.codewind.core.CodewindCorePlugin;
 import org.eclipse.codewind.core.internal.CodewindApplication;
+import org.eclipse.codewind.core.internal.CoreUtil;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.cli.ProjectUtil;
 import org.eclipse.codewind.core.internal.connection.CodewindConnection;
 import org.eclipse.codewind.core.internal.constants.ProjectType;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
+import org.eclipse.codewind.ui.internal.UIConstants;
 import org.eclipse.codewind.ui.internal.actions.OpenAppOverviewAction;
 import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.codewind.ui.internal.prefs.RegistryManagementDialog;
@@ -29,6 +31,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.util.LocalSelectionTransfer;
 import org.eclipse.jface.viewers.ISelection;
@@ -36,6 +39,8 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.dnd.DropTargetEvent;
 import org.eclipse.swt.dnd.TransferData;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.navigator.CommonDropAdapter;
 import org.eclipse.ui.navigator.CommonDropAdapterAssistant;
@@ -93,7 +98,13 @@ public class CodewindNavigatorDropAssistant extends CommonDropAdapterAssistant {
 						Display.getDefault().syncExec(new Runnable() {
 							@Override
 							public void run() {
-								if (MessageDialog.openConfirm(getShell(), Messages.NoPushRegistryTitle, Messages.NoPushRegistryMessage)) {
+								MessageDialog dialog = new MessageDialog(Display.getDefault().getActiveShell(), Messages.NoPushRegistryTitle, null, Messages.NoPushRegistryMessage, MessageDialog.CONFIRM, 0, IDialogConstants.OK_LABEL, IDialogConstants.CANCEL_LABEL) {
+									@Override
+									protected Control createCustomArea(Composite parent) {
+										return CoreUtil.addLinkToDialog(parent, Messages.ImageRegistryDocLinkLabel, UIConstants.REGISTRY_INFO_URL);
+									}
+								};
+								if (dialog.open() == MessageDialog.OK) {
 									RegistryManagementDialog.open(getShell(), targetConn, mon.split(40));
 								} else {
 									mon.setCanceled(true);

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/BindProjectWizard.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/BindProjectWizard.java
@@ -33,6 +33,7 @@ import org.eclipse.codewind.core.internal.connection.ProjectTypeInfo.ProjectSubt
 import org.eclipse.codewind.core.internal.constants.ProjectInfo;
 import org.eclipse.codewind.core.internal.constants.ProjectType;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
+import org.eclipse.codewind.ui.internal.UIConstants;
 import org.eclipse.codewind.ui.internal.actions.CodewindInstall;
 import org.eclipse.codewind.ui.internal.actions.ImportProjectAction;
 import org.eclipse.codewind.ui.internal.actions.OpenAppOverviewAction;
@@ -47,12 +48,15 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.INewWizard;
 import org.eclipse.ui.IWorkbench;
@@ -224,7 +228,13 @@ public class BindProjectWizard extends Wizard implements INewWizard {
 						Display.getDefault().syncExec(new Runnable() {
 							@Override
 							public void run() {
-								if (MessageDialog.openConfirm(getShell(), Messages.NoPushRegistryTitle, Messages.NoPushRegistryMessage)) {
+								MessageDialog dialog = new MessageDialog(Display.getDefault().getActiveShell(), Messages.NoPushRegistryTitle, null, Messages.NoPushRegistryMessage, MessageDialog.CONFIRM, 0, IDialogConstants.OK_LABEL, IDialogConstants.CANCEL_LABEL) {
+									@Override
+									protected Control createCustomArea(Composite parent) {
+										return CoreUtil.addLinkToDialog(parent, Messages.ImageRegistryDocLinkLabel, UIConstants.REGISTRY_INFO_URL);
+									}
+								};
+								if (dialog.open() == MessageDialog.OK) {
 									RegistryManagementDialog.open(getShell(), connection, mon.split(40));
 								} else {
 									mon.setCanceled(true);

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectWizard.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/wizards/NewCodewindProjectWizard.java
@@ -27,6 +27,7 @@ import org.eclipse.codewind.core.internal.connection.CodewindConnection;
 import org.eclipse.codewind.core.internal.connection.CodewindConnectionManager;
 import org.eclipse.codewind.core.internal.connection.ProjectTemplateInfo;
 import org.eclipse.codewind.ui.CodewindUIPlugin;
+import org.eclipse.codewind.ui.internal.UIConstants;
 import org.eclipse.codewind.ui.internal.actions.CodewindInstall;
 import org.eclipse.codewind.ui.internal.actions.ImportProjectAction;
 import org.eclipse.codewind.ui.internal.actions.OpenAppOverviewAction;
@@ -40,11 +41,14 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.INewWizard;
 import org.eclipse.ui.IWorkbench;
@@ -156,7 +160,13 @@ public class NewCodewindProjectWizard extends Wizard implements INewWizard {
 						Display.getDefault().syncExec(new Runnable() {
 							@Override
 							public void run() {
-								if (MessageDialog.openConfirm(getShell(), Messages.NoPushRegistryTitle, Messages.NoPushRegistryMessage)) {
+								MessageDialog dialog = new MessageDialog(Display.getDefault().getActiveShell(), Messages.NoPushRegistryTitle, null, Messages.NoPushRegistryMessage, MessageDialog.CONFIRM, 0, IDialogConstants.OK_LABEL, IDialogConstants.CANCEL_LABEL) {
+									@Override
+									protected Control createCustomArea(Composite parent) {
+										return CoreUtil.addLinkToDialog(parent, Messages.ImageRegistryDocLinkLabel, UIConstants.REGISTRY_INFO_URL);
+									}
+								};
+								if (dialog.open() == MessageDialog.OK) {
 									RegistryManagementDialog.open(getShell(), connection, mon.split(40));
 								} else {
 									mon.setCanceled(true);


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
Adds a link to the image registry documentation on the missing push registry dialog that pops up for Codewind style projects.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2992

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No