### PR TITLE
CW Issue #2997: Show progress monitor while retreiving data needed to open dialog

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -504,6 +504,7 @@ public class Messages extends NLS {
 	public static String AddRepoDialogNoDescription;
 	public static String AddRepoDialogNoUrl;
 	
+	public static String RepoListTask;
 	public static String RepoUpdateTask;
 	public static String RepoUpdateErrorTitle;
 	public static String RepoListErrorTitle;
@@ -555,6 +556,7 @@ public class Messages extends NLS {
 	public static String RegMgmtNamespaceDialogTitle;
 	public static String RegMgmtNamespaceDialogMessage;
 	
+	public static String RegListTask;
 	public static String RegUpdateTask;
 	public static String RegUpdateErrorTitle;
 	public static String RegListErrorTitle;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -498,6 +498,7 @@ AddRepoDialogNoName=Fill in a name for the template source
 AddRepoDialogNoDescription=Fill in a description for the template source
 AddRepoDialogNoUrl=Fill in a URL for the template source
 
+RepoListTask=Retrieving template sources for: {0}
 RepoUpdateTask=Updating template sources
 RepoUpdateErrorTitle=Template Source Update Error
 RepoListErrorTitle=Template Source List Error
@@ -549,6 +550,7 @@ RegMgmtNamespaceDialogShell=Image Registries
 RegMgmtNamespaceDialogTitle=Push Registry Namespace
 RegMgmtNamespaceDialogMessage=If your push registry requires a namespace provide it here, otherwise leave the namespace field empty and click OK.
 
+RegListTask=Retrieving image registries for: {0}
 RegUpdateTask=Updating container registries
 RegUpdateErrorTitle=Container Registry Update Error
 RegListErrorTitle=Container Registry List Error


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Displays a progress monitor while retrieving existing template source or image registry data needed to open the manage template sources or manage image registries dialog. With the progress monitor there will be no unexplained delay between when the user clicks the action and when they see the dialog.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2997

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No