### PR TITLE
CW Issue #2975: Use Eclipse builtin node.js debugger if available

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/CodewindCorePlugin.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/CodewindCorePlugin.java
@@ -50,6 +50,7 @@ public class CodewindCorePlugin extends AbstractUIPlugin {
 			// Int option for debug timeout in seconds
 			DEBUG_CONNECT_TIMEOUT_PREFSKEY = "serverDebugTimeout"; //$NON-NLS-1$
 	
+	public static final String USE_BUILTIN_NODEJS_DEBUG_PREFSKEY = "useBuiltinNodejsDebug"; //$NON-NLS-1$
 	public static final String NODEJS_DEBUG_BROWSER_PREFSKEY = "nodejsDebugBrowserName"; //$NON-NLS-1$
 
 	// The shared instance
@@ -91,6 +92,7 @@ public class CodewindCorePlugin extends AbstractUIPlugin {
 		getPreferenceStore().setDefault(CW_STOP_TIMEOUT, InstallUtil.STOP_TIMEOUT_DEFAULT);
 		getPreferenceStore().setDefault(AUTO_OPEN_OVERVIEW_PAGE, true);
 		getPreferenceStore().setDefault(ENABLE_SUPPORT_FEATURES, false);
+		getPreferenceStore().setDefault(USE_BUILTIN_NODEJS_DEBUG_PREFSKEY, true);
 	}
 
 	/*

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
@@ -151,7 +151,7 @@ public class CodewindEclipseApplication extends CodewindApplication {
 					} else {
 						IDebugLauncher launcher = CodewindCorePlugin.getDebugLauncher(app.projectLanguage.getId());
 						if (launcher != null) {
-							return launcher.launchDebugger(app);
+							return launcher.launchDebugger(app, monitor);
 						}
 					}
 				} catch (Exception e) {

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/IDebugLauncher.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/IDebugLauncher.java
@@ -11,12 +11,13 @@
 
 package org.eclipse.codewind.core.internal;
 
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 
 public interface IDebugLauncher {
 	
-	public IStatus launchDebugger(CodewindApplication app);
+	public IStatus launchDebugger(CodewindEclipseApplication app, IProgressMonitor monitor);
 	
-	public boolean canAttachDebugger(CodewindApplication app);
+	public boolean canAttachDebugger(CodewindEclipseApplication app);
 	
 }

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/launch/RemoteLaunchConfigDelegate.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/launch/RemoteLaunchConfigDelegate.java
@@ -84,6 +84,13 @@ public class RemoteLaunchConfigDelegate extends CodewindLaunchConfigDelegate {
 		String title = NLS.bind(Messages.PortForwardTitle, localPort + ":" + app.getContainerDebugPort());
 		launch.addProcess(new RuntimeProcess(launch, pfInfo.process, title, attributes));
 
+		addDebugEventListener(launch);
+
+		// Launch the debug session
+		super.launch(config, launchMode, launch, monitor);
+	}
+	
+	public static void addDebugEventListener(final ILaunch launch) {
 		// Add the debug listener
 		DebugPlugin.getDefault().addDebugEventListener(new IDebugEventSetListener() {
 			@Override
@@ -109,8 +116,6 @@ public class RemoteLaunchConfigDelegate extends CodewindLaunchConfigDelegate {
 				}
 			}
 		});
-
-		// Launch the debug session
-		super.launch(config, launchMode, launch, monitor);
 	}
+	
 }

--- a/dev/org.eclipse.codewind.ui/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.ui/META-INF/MANIFEST.MF
@@ -21,7 +21,8 @@ Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.codewind.ui.internal,
  org.eclipse.codewind.ui.internal.actions,
  org.eclipse.codewind.ui.internal.editors
-Import-Package: org.eclipse.tm.terminal.view.core,
+Import-Package: org.eclipse.jdt.launching,
+ org.eclipse.tm.terminal.view.core,
  org.eclipse.tm.terminal.view.core.interfaces,
  org.eclipse.tm.terminal.view.core.interfaces.constants,
  org.eclipse.ui,

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/AttachDebuggerAction.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/actions/AttachDebuggerAction.java
@@ -14,6 +14,7 @@ package org.eclipse.codewind.ui.internal.actions;
 import org.eclipse.codewind.core.internal.CodewindEclipseApplication;
 import org.eclipse.codewind.core.internal.Logger;
 import org.eclipse.codewind.core.internal.constants.AppStatus;
+import org.eclipse.codewind.ui.internal.debug.NodeJSDebugLauncher;
 import org.eclipse.codewind.ui.internal.messages.Messages;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -40,7 +41,7 @@ public class AttachDebuggerAction extends SelectionProviderAction {
 			if (obj instanceof CodewindEclipseApplication) {
             	app = (CodewindEclipseApplication) obj;
             	if (app.projectLanguage.isJavaScript()) {
-            		this.setText(Messages.LaunchDebugSessionLabel);
+            		this.setText(NodeJSDebugLauncher.useBuiltinDebugger() ? Messages.AttachDebuggerLabel : Messages.LaunchDebugSessionLabel);
             	} else {
             		this.setText(Messages.AttachDebuggerLabel);
             	}

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/Messages.java
@@ -354,6 +354,8 @@ public class Messages extends NLS {
 	public static String NodeJSDebugPortForwardError;
 	public static String NodeJSDebugURLError;
 	
+	public static String PortForwardTitle;
+	
 	public static String BrowserSelectionTitle;
 	public static String BrowserSelectionDescription;
 	public static String BrowserSelectionLabel;

--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/messages/messages.properties
@@ -348,6 +348,8 @@ NodeJSOpenBrowserJob=Opening browser for Node.js debugging.
 NodeJSDebugPortForwardError=An error occurred trying to forward the debug port for the {0} application.
 NodeJSDebugURLError=Failed to get the debug URL for the {0} application.
 
+PortForwardTitle=Debug port forward {0}
+
 BrowserSelectionTitle=Launch the Node.js Debugger
 BrowserSelectionDescription=Select a Chromium based web browser for launching the Node.js debugger.
 BrowserSelectionLabel=Select a Chromium based &web browser for launching the Node.js debugger:


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
Use the Eclipse builtin node.js debugger if available. Otherwise use the external Chrome based browser as before.


## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2975

## Does this PR require a documentation change ?
Yes

## Any special notes for your reviewer ?
No
