### PR TITLE
CW Issue #3022: Add missing null check for useBuiltinDebugButton in preferences

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/CodewindPrefsParentPage.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/CodewindPrefsParentPage.java
@@ -339,7 +339,9 @@ public class CodewindPrefsParentPage extends PreferencePage implements IWorkbenc
 		// removes any trimmed space
 		debugTimeoutText.setText("" + debugTimeout); //$NON-NLS-1$
 		
-		prefs.setValue(CodewindCorePlugin.USE_BUILTIN_NODEJS_DEBUG_PREFSKEY, useBuiltinDebugButton.getSelection());
+		if (useBuiltinDebugButton != null) {
+			prefs.setValue(CodewindCorePlugin.USE_BUILTIN_NODEJS_DEBUG_PREFSKEY, useBuiltinDebugButton.getSelection());
+		}
 		
 		if (this.webBrowserCombo != null) {
 			// The first option in the webBrowserCombo is to not use the default browser.


### PR DESCRIPTION
#523  What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Adds a null check for useBuiltinDebugButton in performOk.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/3022

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No