### PR TITLE
CW Issue #3024: Don't show indicator for project details with INFO severity

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorLabelProvider.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/views/CodewindNavigatorLabelProvider.java
@@ -137,7 +137,7 @@ public class CodewindNavigatorLabelProvider extends LabelProvider implements ISt
 				} else {
 					if (appStatus != AppStatus.UNKNOWN) {
 						DetailedAppStatus details = app.getAppStatusDetails();
-						if (details != null && details.getMessage() != null) {
+						if (details != null && details.getMessage() != null && details.getSeverity() != Severity.INFO) {
 						    builder.append(" [" + appStatus.getDisplayString(app.getStartMode()) + ": ");
 							if (details.getSeverity() != null) {
 								builder.append("(" + details.getSeverity().displayString + ") ");
@@ -257,7 +257,7 @@ public class CodewindNavigatorLabelProvider extends LabelProvider implements ISt
 				} else {
 					if (appStatus != AppStatus.UNKNOWN) {
 						DetailedAppStatus details = app.getAppStatusDetails();
-						if (details != null && details.getMessage() != null) {
+						if (details != null && details.getMessage() != null && details.getSeverity() != Severity.INFO) {
 							styledString.append(" [" + appStatus.getDisplayString(app.getStartMode()) + ": ", StyledString.DECORATIONS_STYLER);
 							Styler styler = details.getSeverity() != null && details.getSeverity() == Severity.ERROR ? ERROR_STYLER : StyledString.QUALIFIER_STYLER;
 							if (details.getSeverity() != null) {
@@ -346,8 +346,9 @@ public class CodewindNavigatorLabelProvider extends LabelProvider implements ISt
     		}
     	} else if (element instanceof CodewindApplication) {
 			CodewindApplication app = (CodewindApplication)element;
-			if (app.getAppStatusDetails() != null && app.getAppStatusDetails().getMessage() != null) {
-				return app.getAppStatusDetails().getMessage();
+			DetailedAppStatus details = app.getAppStatusDetails();
+			if (details != null && details.getMessage() != null) {
+				return (details.getSeverity() == null ? "" : details.getSeverity().displayString + ": ") + details.getMessage();
 			} else if (app.getRootUrl() != null && (app.getAppStatus() == AppStatus.STARTING || app.getAppStatus() == AppStatus.STARTED)) {
 				return NLS.bind(Messages.CodewindDescriptionContextRoot, app.getRootUrl());
 			}
@@ -357,12 +358,6 @@ public class CodewindNavigatorLabelProvider extends LabelProvider implements ISt
 
 	@Override
 	public String getToolTipText(Object element) {
-		if (element instanceof CodewindApplication) {
-			DetailedAppStatus details = ((CodewindApplication)element).getAppStatusDetails();
-			if (details != null && details.getMessage() != null) {
-				return (details.getSeverity() == null ? "" : details.getSeverity().displayString + ": ") + details.getMessage();
-			}
-		}
 		return getDescription(element);
 	}
 


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Disables the indicator on the project if the message severity is INFO. The hover help will still be there. Also got rid of some duplicate code for the hover help and the description text.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/3024

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No