### PR TITLE
CW Issue #3045: Clear logs link text when no logs available

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
@@ -425,6 +425,7 @@ public class ApplicationOverviewEditorPart extends EditorPart implements UpdateL
 			label.setText(Messages.AppOverviewEditorProjectLogs);
 			label.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, false, false));
 			projectLogs = new Link(composite, SWT.NONE);
+			projectLogs.setText("");
 			projectLogs.setVisible(false);
 			GridData data = new GridData(GridData.BEGINNING, GridData.CENTER, true, false);
 			data.horizontalIndent = 2;
@@ -499,6 +500,7 @@ public class ApplicationOverviewEditorPart extends EditorPart implements UpdateL
 				}
 			} else {
 				boolean changed = !noProjectLogs.getVisible();
+				projectLogs.setText("");
 				IDEUtil.setControlVisibility(projectLogs, false);
 				IDEUtil.setControlVisibility(noProjectLogs, true);
 				if (changed) {


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Clear the logs link text when there are no logs available so that JAWS does not read the old link text along with the "No logs available" text.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/3045

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No