### PR TITLE
CW Issue #3061: Fix background for log links in project overview 0.13.0

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
@@ -430,6 +430,7 @@ public class ApplicationOverviewEditorPart extends EditorPart implements UpdateL
 			data.horizontalIndent = 2;
 			data.exclude = true;
 			projectLogs.setLayoutData(data);
+			IDEUtil.paintBackgroundToMatch(projectLogs, composite);
 			projectLogs.addListener(SWT.Selection, event -> {
 				CodewindEclipseApplication app = (CodewindEclipseApplication) getApp(getConn());
 				if (app == null) {


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Fix the background for the project logs links in the project overview page so that it matches the overall background for the page when using dark mode.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/3061

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No