### PR TITLE
CW Issue #3119: Better detection and message for debug attach timeout

### DIFF
--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/CodewindEclipseApplication.java
@@ -64,7 +64,7 @@ public class CodewindEclipseApplication extends CodewindApplication {
 	public static final String QUICK_FIX_DESCRIPTION = "quickFixDescription";
 	
 	// in seconds
-	public static final int DEFAULT_DEBUG_CONNECT_TIMEOUT = 10;
+	public static final int DEFAULT_DEBUG_CONNECT_TIMEOUT = 180;
 	
 	// New consoles
 	private Set<SocketConsole> activeConsoles = new HashSet<SocketConsole>();
@@ -154,6 +154,8 @@ public class CodewindEclipseApplication extends CodewindApplication {
 							return launcher.launchDebugger(app, monitor);
 						}
 					}
+				} catch (CoreException e) {
+					return e.getStatus();
 				} catch (Exception e) {
 					Logger.logError("An error occurred while trying to launch the debugger for project: " + app.name, e); //$NON-NLS-1$
 					return new Status(IStatus.ERROR, CodewindCorePlugin.PLUGIN_ID,

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/launch/CodewindDebugConnector.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/launch/CodewindDebugConnector.java
@@ -33,6 +33,7 @@ import com.sun.jdi.VirtualMachine;
 import com.sun.jdi.connect.AttachingConnector;
 import com.sun.jdi.connect.Connector;
 import com.sun.jdi.connect.IllegalConnectorArgumentsException;
+import com.sun.jdi.connect.spi.ClosedConnectionException;
 
 @SuppressWarnings("restriction")
 public class CodewindDebugConnector {
@@ -94,6 +95,15 @@ public class CodewindDebugConnector {
 					} catch (InterruptedException e1) {
 						// do nothing
 					}
+				}
+				
+				// Check for timeout
+				if (itr <= 0 && vm == null && (ex == null || ex instanceof ClosedConnectionException)) {
+					// Log any exception
+					if (ex != null) {
+						Logger.logError("Debug connect timed out. Last exception was: " + ex.toString(), ex);
+					}
+					throw new CoreException(new Status(IStatus.ERROR, CodewindCorePlugin.PLUGIN_ID, Messages.DebuggerConnectFailureTimeoutMsg, ex));
 				}
 
 				if (ex instanceof IllegalConnectorArgumentsException) {

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/launch/CodewindLaunchConfigDelegate.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/launch/CodewindLaunchConfigDelegate.java
@@ -75,7 +75,7 @@ public class CodewindLaunchConfigDelegate extends AbstractJavaLaunchConfiguratio
 			launch.addDebugTarget(debugTarget);
 		} else if (!monitor.isCanceled()) {
 			Logger.logError("Debugger connect timeout for project: " + app.name); //$NON-NLS-1$
-			CoreUtil.openDialog(true, Messages.DebuggerConnectFailureDialogTitle, Messages.DebuggerConnectFailureDialogMsg);
+			CoreUtil.openDialog(true, Messages.DebuggerConnectFailureDialogTitle, Messages.DebuggerConnectFailureTimeoutMsg);
 			getLaunchManager().removeLaunch(launch);
 		}
 

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/Messages.java
@@ -45,7 +45,7 @@ public class Messages extends NLS {
 
 	public static String DebugLaunchConfigName;
 	public static String DebuggerConnectFailureDialogTitle;
-	public static String DebuggerConnectFailureDialogMsg;
+	public static String DebuggerConnectFailureTimeoutMsg;
 	
 	public static String RemoteDebugErrorTitle;
 	public static String RemoteDebugPortForwardErrorWithMsg;

--- a/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
+++ b/dev/org.eclipse.codewind.core/src/org/eclipse/codewind/core/internal/messages/messages.properties
@@ -38,7 +38,7 @@ ReconnectJob_ReconnectErrorDialogMsg=Eclipse could not reconnect to {0}.\nRecrea
 
 DebugLaunchConfigName=Debugging {0} at {1}:{2}
 DebuggerConnectFailureDialogTitle=The debugger failed to connect
-DebuggerConnectFailureDialogMsg=The debugger failed to connect in time. Increase the debug timeout in the Codewind preferences.
+DebuggerConnectFailureTimeoutMsg=The debugger failed to connect in time. Increase the debug timeout in the Codewind preferences then right-click on the project and select Attach Debugger.
 
 RemoteDebugErrorTitle=Debug Setup Error
 RemoteDebugPortForwardErrorWithMsg=An error occurred trying to port forward the debug port for the {0} project: {1}


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Works around the problem of the projectRestartResult event coming too soon for appsody projects, before the debug port is ready (see https://github.com/eclipse/codewind/issues/239) by:
- increasing the debug timeout
- checking for the specific exception that occurs when the debug port is not ready and showing a timeout message in this case (the exception is also shown)


## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/3119

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No