### PR TITLE
CW Issue #3162: fix app overview table labels in high contrast

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/editors/ApplicationOverviewEditorPart.java
@@ -690,8 +690,6 @@ public class ApplicationOverviewEditorPart extends EditorPart implements UpdateL
 				data.heightHint = 100;
 				linkTable.setLayoutData(data);
 				
-				linkTable.setHeaderBackground(Display.getCurrent().getSystemColor(SWT.COLOR_WIDGET_LIGHT_SHADOW));
-				
 				// Columns
 				projectColumn = new TableColumn(linkTable, SWT.NONE);
 				projectColumn.setText(projectColumnLabel);


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Stop changing the background colour for table labels in the application overview page as it causes problems with high contrast mode.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/3163

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No