### PR TITLE
CW Issue #3167: Fix missing border on project link env var field

### DIFF
--- a/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/LinkManagementComposite.java
+++ b/dev/org.eclipse.codewind.ui/src/org/eclipse/codewind/ui/internal/prefs/LinkManagementComposite.java
@@ -437,7 +437,7 @@ public class LinkManagementComposite extends Composite {
 			label.setText(Messages.LinkMgmtAddDialogEnvVarLabel);
 			label.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, false, false));
 			
-			envVarText = new Text(composite, SWT.NONE);
+			envVarText = new Text(composite, SWT.BORDER);
 			envVarText.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false));
 			
 			filterText.addModifyListener(new ModifyListener() {


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Fixes the missing border on the add project link dialog environment variable field.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/3167

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No